### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF / DNS rebinding override in crawler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,7 @@ closed pull request.
 No security finding has been rejected in this repository yet. When one is,
 record what was proposed, why it was turned down, and what the correct shape
 looks like, so the next scan starts from the answer rather than the question.
+## 2024-08-14 - SSRF vulnerability in crawler media downloads
+**Vulnerability:** DNS rebinding / SSRF vulnerability when fetching media files.
+**Learning:** `_safe_httpx_client` provides custom secure HTTP transports to protect against SSRF and DNS rebinding. Manually passing a raw `httpx.AsyncHTTPTransport` to it inadvertently overwrites and defeats these security mechanisms.
+**Prevention:** Always rely on `_safe_httpx_client`'s default transport and only configure allowed transport parameters (like retries) if safely exposed by the security library, rather than instantiating and injecting a raw `httpx` transport.

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -683,7 +683,6 @@ async def download_media(
     output_path = Path(output_dir).expanduser().resolve()
     output_path.mkdir(parents=True, exist_ok=True)
 
-    transport = httpx.AsyncHTTPTransport(retries=3)
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -776,7 +775,7 @@ async def download_media(
                 }
 
     async with _safe_httpx_client(
-        timeout=settings.crawler_timeout, transport=transport, headers=headers
+        timeout=settings.crawler_timeout, headers=headers
     ) as client:
         tasks = [_download_one(url, client) for url in media_urls]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
This PR removes the manual `httpx.AsyncHTTPTransport` passed to `_safe_httpx_client` when downloading media in `crawler.py`. 
    
`_safe_httpx_client` leverages a custom transport internally to block SSRF and DNS rebinding attacks. Overriding this argument defeated the security mechanisms entirely for media files.

Prioritizing security over configurable retries, the code now utilizes the default secure transport setup correctly.

---
*PR created automatically by Jules for task [5077952755236785375](https://jules.google.com/task/5077952755236785375) started by @n24q02m*