### PR TITLE
⚡ Bolt: Remove generator expression overhead in lock_project

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,7 @@ closed pull request.
 **Proposed:** annotate the rewritten conditions with a comment naming the optimisation and its expected impact.
 **Why rejected:** this repository is public. A comment that names the tool which wrote it, and asserts an unmeasured speedup, is noise for every later reader of the file.
 **Action:** Write comments that explain why the code is shaped the way it is, in the voice of the surrounding file — for example, the reason a fast path exists and the measurement that justified it. Leave authorship to the commit metadata.
+
+## 2026-08-05 - Avoid generator expressions for simple counting
+**Learning:** Using `sum(1 for x in iterable if condition)` inside loops or functions called frequently adds unnecessary generator creation overhead.
+**Action:** Use an explicit loop with an accumulator variable (e.g., `count += 1`) to avoid generator overhead.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -68,6 +68,6 @@ closed pull request.
 **Why rejected:** this repository is public. A comment that names the tool which wrote it, and asserts an unmeasured speedup, is noise for every later reader of the file.
 **Action:** Write comments that explain why the code is shaped the way it is, in the voice of the surrounding file — for example, the reason a fast path exists and the measurement that justified it. Leave authorship to the commit metadata.
 
-## 2026-08-05 - Avoid generator expressions for simple counting
+## 2026-08-17 - Avoid generator expressions for simple counting
 **Learning:** Using `sum(1 for x in iterable if condition)` inside loops or functions called frequently adds unnecessary generator creation overhead.
 **Action:** Use an explicit loop with an accumulator variable (e.g., `count += 1`) to avoid generator overhead.

--- a/src/wet_mcp/sources/project_lock.py
+++ b/src/wet_mcp/sources/project_lock.py
@@ -212,10 +212,8 @@ def lock_project(db: Any, project_path: Path) -> dict:
         version = entry.get("version", "")
         lib_row = db.get_library(name)
         lib_id = lib_row["id"] if lib_row else None
-
         if lib_row is not None:
             indexed_count += 1
-
         enriched.append(
             {
                 "id": lib_id or name,

--- a/src/wet_mcp/sources/project_lock.py
+++ b/src/wet_mcp/sources/project_lock.py
@@ -206,11 +206,16 @@ def lock_project(db: Any, project_path: Path) -> dict:
     detected = detect_manifests(project_path)
 
     enriched: list[dict] = []
+    indexed_count = 0
     for entry in detected:
         name = entry["id"]
         version = entry.get("version", "")
         lib_row = db.get_library(name)
         lib_id = lib_row["id"] if lib_row else None
+
+        if lib_row is not None:
+            indexed_count += 1
+
         enriched.append(
             {
                 "id": lib_id or name,
@@ -226,7 +231,7 @@ def lock_project(db: Any, project_path: Path) -> dict:
         "project_path": str(project_path),
         "locked_libraries": enriched,
         "total": len(enriched),
-        "indexed": sum(1 for e in enriched if e["indexed"]),
+        "indexed": indexed_count,
     }
 
 

--- a/src/wet_mcp/sources/project_lock.py
+++ b/src/wet_mcp/sources/project_lock.py
@@ -212,8 +212,12 @@ def lock_project(db: Any, project_path: Path) -> dict:
         version = entry.get("version", "")
         lib_row = db.get_library(name)
         lib_id = lib_row["id"] if lib_row else None
+
+        # Calculate indexed count during the main loop to avoid an additional
+        # O(N) iteration and generator creation overhead later.
         if lib_row is not None:
             indexed_count += 1
+
         enriched.append(
             {
                 "id": lib_id or name,


### PR DESCRIPTION
💡 What: The optimization replaces a python generator expression (`sum(1 for ... if e["indexed"])`) that was iterating over the `enriched` list with a simple integer accumulator (`indexed_count`) that is incremented in the existing loop.

🎯 Why: Generator expressions inside frequently called operations add unnecessary overhead. In this case, `enriched` was being built and then immediately traversed again. We can count the truthiness of `lib_row` in the same O(N) pass, saving cycles and allocation overhead.

📊 Impact: Reduces time complexity from two loops to one loop per `detect_manifests` output block, and eliminates Python generator object instantiation inside `lock_project`.

🔬 Measurement: Run the test suite (`uv run pytest`) and benchmark `test_project_lock.py`. Verify no regressions in logic or outputs.

---
*PR created automatically by Jules for task [4073117620020155463](https://jules.google.com/task/4073117620020155463) started by @n24q02m*