### PR TITLE
perf: ⚡ bolt: extract redundant transformations outside any() generator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,6 @@ closed pull request.
 **Proposed:** annotate the rewritten conditions with a comment naming the optimisation and its expected impact.
 **Why rejected:** this repository is public. A comment that names the tool which wrote it, and asserts an unmeasured speedup, is noise for every later reader of the file.
 **Action:** Write comments that explain why the code is shaped the way it is, in the voice of the surrounding file — for example, the reason a fast path exists and the measurement that justified it. Leave authorship to the commit metadata.
+## 2026-08-22 - Extract Redundant Transformations from any() Generators
+**Learning:** Python generator expressions inside `any()` that apply redundant transformations (e.g., `any(skip in u.lower() for skip in skip_patterns)`) are slow due to the transformation being re-evaluated for every element in the iterable.
+**Action:** Always extract redundant transformations outside the `any()` generator (e.g., `u_lower = u.lower()`) to avoid repeated allocations and operations, yielding a cleaner and more efficient check.

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -3411,12 +3411,13 @@ async def _try_sitemap(base_url: str, max_urls: int = 50) -> list[str]:
                     "/_modules/",
                     "/_sources/",
                 )
-                filtered = [
-                    u
-                    for u in urls
-                    if parsed.netloc in u
-                    and not any(skip in u.lower() for skip in skip_patterns)
-                ]
+                filtered = []
+                for u in urls:
+                    if parsed.netloc not in u:
+                        continue
+                    u_lower = u.lower()
+                    if not any(skip in u_lower for skip in skip_patterns):
+                        filtered.append(u)
 
                 if filtered:
                     logger.info(f"Found {len(filtered)} URLs from sitemap at {url}")
@@ -3705,7 +3706,8 @@ async def fetch_docs_pages(
             full_parsed = urlparse(full_url)
 
             # Skip generated index/module pages
-            if any(pat in full_parsed.path.lower() for pat in _skip_url_patterns):
+            full_path_lower = full_parsed.path.lower()
+            if any(pat in full_path_lower for pat in _skip_url_patterns):
                 continue
 
             # GitHub-specific: stay within same repo


### PR DESCRIPTION
💡 What: Extracted `.lower()` calls outside `any()` generator expressions in `src/wet_mcp/sources/docs.py`.
🎯 Why: Calling `.lower()` inside a generator expression provided to `any()` executes the string conversion repeatedly for every item until a match is found. This creates redundant string operations and memory allocations inside tight loops.
📊 Impact: Eliminates redundant O(N) operations and string allocations per URL evaluated, achieving O(1) allocation overhead per evaluation while preserving O(1) space complexity.
🔬 Measurement: Verify via test suite pass that the logic remains correct, and inspect the AST to ensure the transformation occurs strictly once prior to the loop.

---
*PR created automatically by Jules for task [1132276733362929874](https://jules.google.com/task/1132276733362929874) started by @n24q02m*