### PR TITLE
fix: consolidate documentation URL skip filters

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -2685,6 +2685,45 @@ _GH_REPO_RE = re.compile(r"github\.com/([^/]+)/([^/]+?)(?:\.git)?(?:/|$)")
 
 # Common docs directory names in repos
 _DOC_DIRS = ("docs", "doc", "documentation", "guide", "guides", "wiki")
+_SITEMAP_SKIP_RE = re.compile(
+    "|".join(
+        re.escape(path)
+        for path in (
+            "/blog/",
+            "/changelog",
+            "/releases",
+            "/feed",
+            "/rss",
+            "/sitemap",
+            "/robots.txt",
+            "/search",
+            "/genindex",
+            "/searchindex",
+            "/modindex",
+            "/_modules/",
+            "/_sources/",
+        )
+    ),
+    re.IGNORECASE,
+)
+
+_SPIDER_SKIP_RE = re.compile(
+    "|".join(
+        re.escape(path)
+        for path in (
+            "/genindex",
+            "/searchindex",
+            "/modindex",
+            "/_modules/",
+            "/_sources/",
+            "/blog/",
+            "/changelog",
+            "/releases",
+        )
+    ),
+    re.IGNORECASE,
+)
+
 
 # Non-documentation files to skip (case-insensitive stem matching)
 _SKIP_FILES = frozenset(
@@ -3395,27 +3434,11 @@ async def _try_sitemap(base_url: str, max_urls: int = 50) -> list[str]:
                 else:
                     urls = re.findall(r"<loc>\s*(.*?)\s*</loc>", text)
 
-                # Filter to same domain, skip non-doc paths
-                skip_patterns = (
-                    "/blog/",
-                    "/changelog",
-                    "/releases",
-                    "/feed",
-                    "/rss",
-                    "/sitemap",
-                    "/robots.txt",
-                    "/search",
-                    "/genindex",
-                    "/searchindex",
-                    "/modindex",
-                    "/_modules/",
-                    "/_sources/",
-                )
+                # Filter to same domain, skip non-doc paths.
                 filtered = [
                     u
                     for u in urls
-                    if parsed.netloc in u
-                    and not any(skip in u.lower() for skip in skip_patterns)
+                    if parsed.netloc in u and not _SITEMAP_SKIP_RE.search(u)
                 ]
 
                 if filtered:
@@ -3659,18 +3682,6 @@ async def fetch_docs_pages(
         "why-github",
     }
 
-    # Generated/index pages to skip (Sphinx, MkDocs, etc.)
-    _skip_url_patterns = (
-        "/genindex",
-        "/searchindex",
-        "/modindex",
-        "/_modules/",
-        "/_sources/",
-        "/blog/",
-        "/changelog",
-        "/releases",
-    )
-
     # Detect redirect: if actual URL differs from docs_url (e.g., versioned
     # docs), use the redirected path as prefix to restrict crawling to that
     # version.  Prevents crawling sibling version pages (/en/13/, /en/14/).
@@ -3704,8 +3715,8 @@ async def fetch_docs_pages(
                 continue
             full_parsed = urlparse(full_url)
 
-            # Skip generated index/module pages
-            if any(pat in full_parsed.path.lower() for pat in _skip_url_patterns):
+            # Skip generated index/module pages.
+            if _SPIDER_SKIP_RE.search(full_parsed.path):
                 continue
 
             # GitHub-specific: stay within same repo

--- a/tests/test_docs_comprehensive.py
+++ b/tests/test_docs_comprehensive.py
@@ -329,6 +329,8 @@ async def test_try_sitemap_success():
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://docs.test/guide</loc></url>
   <url><loc>https://docs.test/api</loc></url>
+  <url><loc>https://docs.test/BLOG/post</loc></url>
+  <url><loc>https://docs.test/searchindex</loc></url>
 </urlset>"""
         mock_instance.get.return_value = mock_resp
 


### PR DESCRIPTION
## Summary
- precompile the sitemap and crawler non-documentation path filters once
- use case-insensitive regex search to preserve skip semantics without repeated lower/allocation work
- add sitemap regression coverage for mixed-case generated paths

## Verification
- docs regression files: 206 passed
- full non-live suite: 2399 passed, 35 skipped, 140 deselected, 17 warnings
- project-environment pre-commit hooks: passed

This clean source/test replacement supersedes the duplicate Bolt PRs #1692, #1695, #1696, #1698, #1699, #1702, #1703, and #1704.