### PR TITLE
fix: align wet retrieval contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
-    "fastretrieval>=1.0.1",
+    "fastretrieval>=1.1.0b1,<2",
     "pillow>=12.3.0",
     "diskcache>=5.6.3",
     "cryptography>=50.0.0",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/wet-mcp",
-  "description": "MCP server for web search, content extraction, academic research, and library docs.",
+  "description": "Web search, content extraction, and library docs for AI agents -- 5-strategy scraping, runs without API keys.",
   "repository": {
     "url": "https://github.com/n24q02m/wet-mcp.git",
     "source": "github"

--- a/src/wet_mcp/docs/config.md
+++ b/src/wet_mcp/docs/config.md
@@ -12,7 +12,7 @@ Show current server configuration and status.
 {"action": "status"}
 ```
 
-Returns: database stats, embedding model, cache status, SearXNG status, sync settings.
+Returns: database stats, embedding status (`backend`, resolved `model`, stored `dims`, `available`, and `unavailable_reason` when disabled), reranker status (`backend`, resolved `model`, `available`), cache status, SearXNG status, and sync settings.
 
 ### set
 

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2107,6 +2107,14 @@ def _active_docs_backend() -> str:
     return os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
 
 
+def _backend_model_identity(backend: Any) -> str | None:
+    """Return the resolved model id without exposing backend internals."""
+    if backend is None:
+        return None
+    model = getattr(backend, "model", None) or getattr(backend, "_model_name", None)
+    return model if isinstance(model, str) else None
+
+
 async def _handle_config_status() -> dict[str, Any]:
     await _wait_for_backend_init()
 
@@ -2157,6 +2165,7 @@ async def _handle_config_status() -> dict[str, Any]:
         },
         "embedding": {
             "backend": (type(embed_backend).__name__ if embed_backend else None),
+            "model": _backend_model_identity(embed_backend),
             "dims": _embedding_dims,
             "available": embed_backend is not None,
             # "available: false" on its own reads as a fault. Most of the time
@@ -2168,6 +2177,7 @@ async def _handle_config_status() -> dict[str, Any]:
         "reranker": {
             "available": reranker is not None,
             "backend": (type(reranker).__name__ if reranker else None),
+            "model": _backend_model_identity(reranker),
         },
         "cache": {
             "enabled": settings.wet_cache,

--- a/tests/test_disable_local_per_request_resolution.py
+++ b/tests/test_disable_local_per_request_resolution.py
@@ -353,6 +353,26 @@ class TestConfigStatusReflectsPerRequestResolution:
         assert status["embedding"]["backend"] == "CloudEmbeddingBackend"
         assert status["embedding"]["available"] is True
 
+    async def test_embedding_status_records_model_and_dimensions(self, monkeypatch):
+        from wet_mcp import embedder
+        from wet_mcp.server import _handle_config_status
+
+        monkeypatch.setattr(embedder, "_backend", None)
+        monkeypatch.setattr("wet_mcp.server._embedding_dims", 768)
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+                "JINA_AI_API_KEY": "jina_a",
+            },
+        )
+        set_current_sub("user_a")
+
+        status = await _handle_config_status()
+
+        assert status["embedding"]["model"] == "jina_ai/jina-embeddings-v5-text-small"
+        assert status["embedding"]["dims"] == 768
+
     async def test_reranker_reads_unavailable_when_the_request_has_no_backend(
         self, local_rerank_disabled, monkeypatch
     ):

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -49,6 +49,7 @@ def mock_settings():
         mock.resolve_rerank_backend.return_value = "cloud"
         mock.resolve_embedding_model.return_value = "gemini"
         mock.resolve_rerank_model.return_value = "gemini-rerank"
+        mock.embedding_chain.return_value = ["gemini"]
         mock.wet_auto_searxng = False
         mock.setup_providers.return_value = "sdk"
         # For tests, pretend we don't have timeout so tasks run synchronously

--- a/uv.lock
+++ b/uv.lock
@@ -787,7 +787,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.0.1"
+version = "1.1.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -798,9 +798,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/35/2a91b42d6b9784ee620d4c75bd2abadbcbd3cf304dcb0a41f5a3a22ee0ba/fastretrieval-1.0.1.tar.gz", hash = "sha256:a1d766e1c1471347ba830c4a7f280ed7b0ff86fbc48425ac457b7b9d8d0e5783", size = 330230, upload-time = "2026-08-14T16:58:25.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2b/00cccf6ead62dc473fb3eccfccd222ca9f481dc85acacb568f49700d159e/fastretrieval-1.1.0b1.tar.gz", hash = "sha256:f5d0609d8255bb66647b65071c802af7401840ba6fedd0d39f93b477fba9722e", size = 330569, upload-time = "2026-08-22T12:47:25.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/94/28ba6e0d86b4b8bb0f2a687d5669bd3c6adb7c3346d6e80431fb66ba6c2d/fastretrieval-1.0.1-py3-none-any.whl", hash = "sha256:902851b02c6b1ffefc66aa63c7976a2226696d7ea2b43b9ec471029e97e58892", size = 144199, upload-time = "2026-08-14T16:58:24.195Z" },
+    { url = "https://files.pythonhosted.org/packages/51/df/bc661390b5a1f06ec476ee23e0e9e848f865b3e80543fcb74e5bf0a254b5/fastretrieval-1.1.0b1-py3-none-any.whl", hash = "sha256:a741bb849e7324d0e11d07b23237b278e45b294c1770ef9a036a77310ebb6bad", size = 144434, upload-time = "2026-08-22T12:47:24.442Z" },
 ]
 
 [[package]]
@@ -2932,8 +2932,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3260,18 +3260,18 @@ name = "unclecode-litellm"
 version = "1.81.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "sys_platform != 'win32'" },
+    { name = "click", marker = "sys_platform != 'win32'" },
+    { name = "fastuuid", marker = "sys_platform != 'win32'" },
+    { name = "httpx", marker = "sys_platform != 'win32'" },
+    { name = "importlib-metadata", marker = "sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform != 'win32'" },
+    { name = "jsonschema", marker = "sys_platform != 'win32'" },
+    { name = "openai", marker = "sys_platform != 'win32'" },
+    { name = "pydantic", marker = "sys_platform != 'win32'" },
+    { name = "python-dotenv", marker = "sys_platform != 'win32'" },
+    { name = "tiktoken", marker = "sys_platform != 'win32'" },
+    { name = "tokenizers", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/c4/93ed52c49c2347184f908c692ebb7c1f06303805910774c3282ac68033db/unclecode_litellm-1.81.13.tar.gz", hash = "sha256:db70e34e3e859c0a07f02cb02eaa644f8fa4b4ecc5e2f3be9a58bd7d1c3feedc", size = 16678208, upload-time = "2026-03-24T14:46:31.915Z" }
 wheels = [
@@ -3426,7 +3426,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.7.3"
+version = "3.7.4b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3477,7 +3477,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
-    { name = "fastretrieval", specifier = ">=1.0.1" },
+    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
     { name = "google-api-python-client", specifier = ">=2.198.0" },
     { name = "google-auth", specifier = ">=2.56.2" },
     { name = "greenlet", specifier = "<3.5.6" },


### PR DESCRIPTION
## Summary
- require the published `fastretrieval>=1.1.0b1,<2` public contract and lock exact 1.1.0b1
- expose resolved embedding/reranker model identity in config status
- align config docs and MCP registry description

## Verification
- `uv lock --locked`
- `uv run pytest tests -k "embedding or retrieval or setup or model" -q` — 307 passed, 1 skipped
- real stdio MCP search + extract smoke — 2 passed

Stable promotion is intentionally out of scope.