### PR TITLE
fix: repair registry release and stable retrieval pins

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-mcp",
-  "description": "Web search, content extraction, and media download",
+  "description": "Open-source MCP server for AI agents: web search, content extraction, and library docs.",
   "version": "3.8.0",
   "userConfig": {
     "EMBEDDING_MODELS": {

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -209,6 +209,8 @@ jobs:
       - name: Install MCP Publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Validate MCP Registry manifest
+        run: ./mcp-publisher validate server.json
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,7 @@ mise run dev       # uv run wet-mcp
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
  - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
- - Local model cache: `FASTRETRIEVAL_CACHE_PATH` (preferred); the old
-   `QWEN3_EMBED_CACHE_PATH` name is still honored when the new name is absent.
+ - Local model cache: `FASTRETRIEVAL_CACHE_PATH`.
 - X/Twitter search (`search` action `x`): `XAI_API_KEY` (from skret `/wet-mcp/prod`), `X_SEARCH_MODEL` (default `grok-4.3` ~$0.032/query; `grok-4.5` ~$0.12/query). Transport = `litellm.aresponses` (OpenAI Responses API shape), NOT `mcp_core.llm.acompletion`: xAI's `x_search` server-side tool is only accepted on `/v1/responses` — the chat-completions endpoint rejects `tools=[{"type":"x_search"}]` with `unknown variant 'x_search'`. litellm forwards the server tool and returns the same `AnnotationURLCitation` shape as the raw openai SDK, so no direct provider-SDK dep is added. Citations gotcha: `response.citations` is absent on this path — parse them from the `output_text` block's `annotations`. See `sources/x_search.py`.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,7 @@ mise run dev       # uv run wet-mcp
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
  - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
- - Local model cache: `FASTRETRIEVAL_CACHE_PATH` (preferred); the old
-   `QWEN3_EMBED_CACHE_PATH` name is still honored when the new name is absent.
+ - Local model cache: `FASTRETRIEVAL_CACHE_PATH`.
 - X/Twitter search (`search` action `x`): `XAI_API_KEY` (from skret `/wet-mcp/prod`), `X_SEARCH_MODEL` (default `grok-4.3` ~$0.032/query; `grok-4.5` ~$0.12/query). Transport = `litellm.aresponses` (OpenAI Responses API shape), NOT `mcp_core.llm.acompletion`: xAI's `x_search` server-side tool is only accepted on `/v1/responses` — the chat-completions endpoint rejects `tools=[{"type":"x_search"}]` with `unknown variant 'x_search'`. litellm forwards the server tool and returns the same `AnnotationURLCitation` shape as the raw openai SDK, so no direct provider-SDK dep is added. Citations gotcha: `response.citations` is absent on this path — parse them from the `output_text` block's `annotations`. See `sources/x_search.py`.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/wet-mcp
 
-**Web search, content extraction, and library docs for AI agents -- 5-strategy scraping, runs without API keys.**
+**Open-source MCP server for AI agents: web search, content extraction, and library docs.**
 
 | Phase | Status | Scope |
 |---|---|---|
@@ -162,8 +162,7 @@ matching key (litellm `<PROVIDER>_API_KEY` convention):
 Any other litellm provider works via env passthrough -- see
 [litellm provider docs](https://docs.litellm.ai/docs/providers) for its key name.
 
-`FASTRETRIEVAL_CACHE_PATH` controls the local model cache. The old
-`QWEN3_EMBED_CACHE_PATH` name is still honored when the new name is absent.
+`FASTRETRIEVAL_CACHE_PATH` controls the local model cache.
 
 **Search backends** -- `SEARCH_BACKENDS` (CSV, runtime fallback chain) over
 `searxng` (default, local) plus optional cloud providers `tavily` / `brave` /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wet-mcp"
 version = "3.8.0"
-description = "Open-source MCP Server for web search, extract, crawl, academic research, and library docs with embedded SearXNG"
+description = "Open-source MCP server for AI agents: web search, content extraction, and library docs."
 readme = "README.md"
 license = { text = "Apache-2.0" }
 authors = [{ name = "n24q02m", email = "quangminh2422004@gmail.com" }]
@@ -23,7 +23,7 @@ dependencies = [
     # wet consumes web-core's SSRF surface (is_safe_url / safe_httpx_client) AND, since 2.3.0,
     # the remote render backends (CFBrowserRenderingClient / BrowserlessClient /
     # RemoteRenderStrategy) for the browser provider chain + the under-rendered escalation fix.
-    "n24q02m-web-core>=2.4.0,<3",
+    "n24q02m-web-core>=2.5.0,<3",
     # MCP Server
     "mcp[cli]",
     # HTTP Client
@@ -44,7 +44,7 @@ dependencies = [
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
-    "fastretrieval>=1.1.0b1,<2",
+    "fastretrieval>=1.1.0,<2",
     "pillow>=12.3.0",
     "diskcache>=5.6.3",
     "cryptography>=50.0.0",
@@ -65,7 +65,7 @@ dependencies = [
     # mcp_core.storage.d1 / mcp_core.storage.vectorize, the shared D1 +
     # Vectorize HTTP clients this server now imports instead of keeping its
     # own copy under wet_mcp.backends.
-    "n24q02m-mcp-core[llm]>=1.23.0,<2",
+    "n24q02m-mcp-core[llm]>=1.23.1,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",
     # fastmcp arrives transitively via mcp-core; both bounds are pinned here,

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/wet-mcp",
-  "description": "Web search, content extraction, and library docs for AI agents -- 5-strategy scraping, runs without API keys.",
+  "description": "Open-source MCP server for AI agents: web search, content extraction, and library docs.",
   "repository": {
     "url": "https://github.com/n24q02m/wet-mcp.git",
     "source": "github"

--- a/src/wet_mcp/setup_tool.py
+++ b/src/wet_mcp/setup_tool.py
@@ -15,18 +15,10 @@ from wet_mcp.config import settings
 
 
 def _resolve_cache_dir() -> Path:
-    """Resolve the fastretrieval cache path with an intentional old alias."""
-    new = os.getenv("FASTRETRIEVAL_CACHE_PATH")
-    if new:
-        return Path(new)
-
-    old = os.getenv("QWEN3_EMBED_CACHE_PATH")
-    if old:
-        logger.warning(
-            "QWEN3_EMBED_CACHE_PATH is deprecated; use "
-            "FASTRETRIEVAL_CACHE_PATH instead. Still honoring it."
-        )
-        return Path(old)
+    """Resolve the fastretrieval cache path."""
+    explicit = os.getenv("FASTRETRIEVAL_CACHE_PATH")
+    if explicit:
+        return Path(explicit)
 
     xdg_cache_home = os.getenv("XDG_CACHE_HOME")
     base_path = Path(xdg_cache_home) if xdg_cache_home else Path.home() / ".cache"

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -2273,7 +2273,7 @@ class TestSetupTool:
         cache_dir.mkdir(parents=True)
         (cache_dir / "file.bin").write_bytes(b"data")
 
-        with patch.dict(os.environ, {"QWEN3_EMBED_CACHE_PATH": str(tmp_path)}):
+        with patch.dict(os.environ, {"FASTRETRIEVAL_CACHE_PATH": str(tmp_path)}):
             result = clear_model_cache("test/model")
             assert result is not None
             assert not cache_dir.exists()
@@ -2282,7 +2282,7 @@ class TestSetupTool:
         """Returns None when no cache."""
         from wet_mcp.setup_tool import clear_model_cache
 
-        with patch.dict(os.environ, {"QWEN3_EMBED_CACHE_PATH": str(tmp_path)}):
+        with patch.dict(os.environ, {"FASTRETRIEVAL_CACHE_PATH": str(tmp_path)}):
             result = clear_model_cache("nonexistent/model")
             assert result is None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,7 +36,7 @@ class TestClearModelCache:
         (model_dir / "blobs").mkdir()
         (model_dir / "blobs" / "abc.incomplete").touch()
 
-        with patch.dict("os.environ", {"QWEN3_EMBED_CACHE_PATH": str(tmp_path)}):
+        with patch.dict("os.environ", {"FASTRETRIEVAL_CACHE_PATH": str(tmp_path)}):
             result = clear_model_cache("org/model")
 
         assert not model_dir.exists()
@@ -45,33 +45,33 @@ class TestClearModelCache:
     def test_noop_when_cache_missing(self, tmp_path):
         from wet_mcp.setup_tool import clear_model_cache
 
-        with patch.dict("os.environ", {"QWEN3_EMBED_CACHE_PATH": str(tmp_path)}):
+        with patch.dict("os.environ", {"FASTRETRIEVAL_CACHE_PATH": str(tmp_path)}):
             result = clear_model_cache("nonexistent/model")
 
         assert result is None
 
-    def test_new_cache_env_wins_over_old_alias(self, tmp_path):
+    def test_explicit_cache_env_wins_over_xdg_default(self, tmp_path):
         from wet_mcp.setup_tool import clear_model_cache
 
-        old_dir = tmp_path / "old"
-        new_dir = tmp_path / "new"
-        old_model = old_dir / "models--org--model"
-        new_model = new_dir / "models--org--model"
-        old_model.mkdir(parents=True)
-        new_model.mkdir(parents=True)
+        xdg_dir = tmp_path / "xdg"
+        explicit_dir = tmp_path / "explicit"
+        xdg_model = xdg_dir / "fastretrieval" / "models--org--model"
+        explicit_model = explicit_dir / "models--org--model"
+        xdg_model.mkdir(parents=True)
+        explicit_model.mkdir(parents=True)
 
         with patch.dict(
             "os.environ",
             {
-                "FASTRETRIEVAL_CACHE_PATH": str(new_dir),
-                "QWEN3_EMBED_CACHE_PATH": str(old_dir),
+                "FASTRETRIEVAL_CACHE_PATH": str(explicit_dir),
+                "XDG_CACHE_HOME": str(xdg_dir),
             },
         ):
             result = clear_model_cache("org/model")
 
-        assert result == str(new_model)
-        assert not new_model.exists()
-        assert old_model.exists()
+        assert result == str(explicit_model)
+        assert not explicit_model.exists()
+        assert xdg_model.exists()
 
 
 class TestDownloadLocalEmbedding:

--- a/tests/test_manifest_runtime_migration.py
+++ b/tests/test_manifest_runtime_migration.py
@@ -1,0 +1,121 @@
+"""Release manifest and local-runtime migration contracts."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def _job_block(workflow: str, job: str) -> str:
+    lines = workflow.splitlines()
+    start = lines.index(f"  {job}:")
+    for offset, line in enumerate(lines[start + 1 :], start=start + 1):
+        if line.startswith("  ") and line.endswith(":") and not line.startswith("    "):
+            return "\n".join(lines[start:offset])
+    return "\n".join(lines[start:])
+
+
+def _project_metadata() -> dict:
+    return tomllib.loads(_read("pyproject.toml"))
+
+
+def _locked_package(name: str) -> dict:
+    lock = tomllib.loads(_read("uv.lock"))
+    return next(package for package in lock["package"] if package["name"] == name)
+
+
+def test_registry_description_matches_project_and_is_at_most_100_characters():
+    manifest = json.loads(_read("server.json"))
+    project = _project_metadata()["project"]
+
+    assert manifest["description"] == project["description"]
+    assert 0 < len(manifest["description"]) <= 100
+
+
+def test_mcp_registry_validates_manifest_before_login_and_publish():
+    registry_job = _job_block(_read(".github/workflows/cd.yml"), "publish-mcp-registry")
+
+    validate_at = registry_job.index("./mcp-publisher validate server.json")
+    login_at = registry_job.index("./mcp-publisher login github-oidc")
+    publish_at = registry_job.index("./mcp-publisher publish")
+
+    assert validate_at < login_at
+    assert validate_at < publish_at
+
+
+def test_dependency_specs_and_lock_use_stable_migrations():
+    project = _project_metadata()["project"]
+    dependencies = project["dependencies"]
+
+    assert "fastretrieval>=1.1.0,<2" in dependencies
+    assert "n24q02m-mcp-core[llm]>=1.23.1,<2" in dependencies
+    assert _locked_package("fastretrieval")["version"] == "1.1.0"
+    assert _locked_package("n24q02m-mcp-core")["version"] == "1.23.1"
+
+
+async def test_local_embedding_uses_fastretrieval_output_contract(monkeypatch):
+    from wet_mcp.embedder import LocalEmbeddingBackend
+
+    calls: dict[str, object] = {}
+
+    class FakeEmbedding:
+        def embed(self, texts, **kwargs):
+            calls["texts"] = texts
+            calls["kwargs"] = kwargs
+            return iter([np.array([0.1, 0.2])])
+
+    backend = LocalEmbeddingBackend("stable-model")
+    monkeypatch.setattr(backend, "_get_model", lambda: FakeEmbedding())
+
+    vectors = await backend.embed_texts(["document"], dimensions=2)
+
+    assert vectors == [[0.1, 0.2]]
+    assert calls == {"texts": ["document"], "kwargs": {"dim": 2}}
+
+
+def test_local_reranker_uses_fastretrieval_score_contract(monkeypatch):
+    from wet_mcp.reranker import LocalReranker
+
+    class FakeCrossEncoder:
+        def rerank(self, query, documents):
+            assert query == "query"
+            assert documents == ["low", "high"]
+            return iter([0.1, 0.9])
+
+    reranker = LocalReranker("stable-model")
+    monkeypatch.setattr(reranker, "_get_model", lambda: FakeCrossEncoder())
+
+    assert reranker.rerank("query", ["low", "high"], top_n=2) == [
+        (1, 0.9),
+        (0, 0.1),
+    ]
+
+
+def test_legacy_qwen_cache_variable_does_not_select_cache(tmp_path, monkeypatch):
+    from wet_mcp.setup_tool import clear_model_cache
+
+    legacy_dir = tmp_path / "legacy"
+    active_dir = tmp_path / "xdg" / "fastretrieval"
+    legacy_model = legacy_dir / "models--org--model"
+    active_model = active_dir / "models--org--model"
+    legacy_model.mkdir(parents=True)
+    active_model.mkdir(parents=True)
+
+    monkeypatch.delenv("FASTRETRIEVAL_CACHE_PATH", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("QWEN3_EMBED_CACHE_PATH", str(legacy_dir))
+
+    result = clear_model_cache("org/model")
+
+    assert result == str(active_model)
+    assert not active_model.exists()
+    assert legacy_model.exists()

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -1,6 +1,4 @@
-"""Guard: wet-mcp must depend on a mcp-core release that ships the storage
-backends (CredentialBackend / CfKvBackend) AND the PerPluginStore token sub-key.
-"""
+"""Guard: wet-mcp must depend on the stable mcp-core storage and LLM APIs."""
 
 import re
 import tomllib
@@ -9,17 +7,14 @@ from pathlib import Path
 from packaging.version import Version
 
 
-def test_mcp_core_pin_includes_token_subkey():
+def test_mcp_core_pin_is_stable_1_23_1_or_newer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
-    # Storage backends + token sub-key + CfKvBackend.ready() shipped by 1.18.0b12;
-    # the mcp_core.llm.key_rotation primitive (split_keys / rotate_keys) used by the
-    # search-backend multi-key rotation shipped in 1.18.0b14. Compare the >= floor as
-    # a version (not a brittle substring) so legitimate bumps past b14 still pass.
+
     m = re.search(r">=\s*([0-9][0-9A-Za-z.\-]*)", core)
     assert m, f"no >= floor in pin: {core}"
-    assert Version(m.group(1)) >= Version("1.18.0b14"), f"floor too low: {core}"
+    assert Version(m.group(1)) >= Version("1.23.1"), f"floor too low: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/tests/test_no_stale_package_name.py
+++ b/tests/test_no_stale_package_name.py
@@ -8,8 +8,6 @@ TEST_FILE = Path(__file__).resolve().relative_to(ROOT).as_posix()
 
 # CHANGELOG ghi lại lịch sử; tên gói cũ ở đó là đúng và phải giữ nguyên.
 ALLOWED = {"CHANGELOG.md"}
-# Tên biến cũ được đọc có chủ ý để không làm vỡ cấu hình người dùng cũ.
-ALLOWED_LINES = ("QWEN3_EMBED_CACHE_PATH",)
 
 
 def _tracked_hits(pattern: str) -> list[str]:
@@ -26,7 +24,6 @@ def _tracked_hits(pattern: str) -> list[str]:
         if line
         and not line.startswith(f"{TEST_FILE}:")
         and not any(line.startswith(f"{name}:") for name in ALLOWED)
-        and not any(token in line for token in ALLOWED_LINES)
     ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.1.0b2"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -795,9 +795,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/bf/7e16cba2cd2a3cb8f1eeec013b2ee55ba2ec9cd88c4edadfb872f0ffaa35/fastretrieval-1.1.0b2.tar.gz", hash = "sha256:439adebaaec715447d2c108382b5b8826a7d2065af77eadd8cc01a7914ad6236", size = 331046, upload-time = "2026-08-24T15:25:24.915Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/be/00314cfc1aafdf3089e4384e319f32f106ca6dd63184c4583bb3e92114b2/fastretrieval-1.1.0.tar.gz", hash = "sha256:53b958b7b29a18c4ff6982bfd74c3d2b71f5e213c2ef794bbd89a0672361cdc8", size = 316103, upload-time = "2026-08-29T12:43:06.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/42/39afed64b4181da8d1fee647e77ad82c57742704933f1a75398f8be0fc25/fastretrieval-1.1.0b2-py3-none-any.whl", hash = "sha256:9d3bcd6c161680b1165b4029a2e05d3cfb24c3549d67d7ee37f78e654908a0d6", size = 144565, upload-time = "2026-08-24T15:25:23.549Z" },
+    { url = "https://files.pythonhosted.org/packages/95/de/3e05f7c5cd33dd5716233a87e15a99c95fa8cc2c3dae53e3b0d60bc85977/fastretrieval-1.1.0-py3-none-any.whl", hash = "sha256:3c371d3fb8f76d1e029c9bd99adf8118cf0d49259c6a50649027324ba320e4ec", size = 144628, upload-time = "2026-08-29T12:43:04.505Z" },
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.23.0"
+version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1830,12 +1830,13 @@ dependencies = [
     { name = "loguru" },
     { name = "platformdirs" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/14/31d9b330fd59e891f73ad0b06e38a15f620325ef46b5cab5b6e3fd64fd83/n24q02m_mcp_core-1.23.0.tar.gz", hash = "sha256:cf6010adc23d433634d901ce550fd26f8c8fb754097a5a6e9d920ef3d48ac936", size = 358930, upload-time = "2026-08-07T22:48:12.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ea/060df6d5c00c13a7e5ffe7bf04536bcbbc5577d68180d0533be3b8096f27/n24q02m_mcp_core-1.23.1.tar.gz", hash = "sha256:4408b14f73c16163048988e8b429fd73a02ffe83a4b4b8ffeef312ab843606a9", size = 364418, upload-time = "2026-08-29T12:46:36.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/2e/7d7a275171a6455b45df7468d0232484b68973f8e255c71696be56f70e7b/n24q02m_mcp_core-1.23.0-py3-none-any.whl", hash = "sha256:cc738b004299056419247e53da2824bd3745dc84a8cd49bf401f59e46d9e4933", size = 195465, upload-time = "2026-08-07T22:48:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/5ab34cca3f47402314622bd61e755d3c19ea4433676433a8536d6c7507df/n24q02m_mcp_core-1.23.1-py3-none-any.whl", hash = "sha256:8feac38084817544a1f9b9d256ec1b1d78584e971ab9967ba5a9526a6bbf01e6", size = 196653, upload-time = "2026-08-29T12:46:35.66Z" },
 ]
 
 [package.optional-dependencies]
@@ -1845,7 +1846,7 @@ llm = [
 
 [[package]]
 name = "n24q02m-web-core"
-version = "2.4.0"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "browserforge" },
@@ -1859,9 +1860,9 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/d9/1554544a6a5e1230d57116ffd2aebac7b28d97007fc36cbe56a5be150ba9/n24q02m_web_core-2.4.0.tar.gz", hash = "sha256:7b9e0db5a74e608a2c317f74c996cf3d69be7e895bcacfa81123eb833c7f80c3", size = 258028, upload-time = "2026-08-07T22:48:00.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/0d/b314381dc0c4cc43e2fac0f4655d36beb9a19f4e2b5e73025e7525432529/n24q02m_web_core-2.5.0.tar.gz", hash = "sha256:744076ff555c5ba2f8683f438273190ae34be77e1ca723c75c58464101c24478", size = 262506, upload-time = "2026-08-29T12:44:47.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/70/ad4d44476c028b984d9d8827b7a636cb586686e9f4d35e6664abe4d81414/n24q02m_web_core-2.4.0-py3-none-any.whl", hash = "sha256:2b3c91dde86eb6010755e99bd58bf32141486c9ccc4a3ca04f81296d5f0bbc2a", size = 73415, upload-time = "2026-08-07T22:47:59.785Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ab/02f691a6620d3bde03738064eb97b88614206691579dde71975a43961725/n24q02m_web_core-2.5.0-py3-none-any.whl", hash = "sha256:60c83e42d231057a5638e51162b6e416d7b3fc68473a38b7c33989ccce68a016", size = 73770, upload-time = "2026-08-29T12:44:46.936Z" },
 ]
 
 [[package]]
@@ -2412,16 +2413,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.15.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -3420,7 +3421,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.7.4b1"
+version = "3.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3471,7 +3472,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
-    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
+    { name = "fastretrieval", specifier = ">=1.1.0,<2" },
     { name = "google-api-python-client", specifier = ">=2.198.0" },
     { name = "google-auth", specifier = ">=2.56.2" },
     { name = "greenlet", specifier = "<3.5.6" },
@@ -3482,8 +3483,8 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.23.0,<2" },
-    { name = "n24q02m-web-core", specifier = ">=2.4.0,<3" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.23.1,<2" },
+    { name = "n24q02m-web-core", specifier = ">=2.5.0,<3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },


### PR DESCRIPTION
## Problem
Stable run 33252970755 published PyPI and deployed Cloudflare, but MCP Registry rejected the overlong description and marketplace sync skipped. The runtime also still carried beta retrieval/core floors and a legacy QWEN3 cache alias.

## Fix
- canonical <=100-character manifest/project/plugin/README description
- official `mcp-publisher validate server.json` before login/publish
- stable `fastretrieval>=1.1.0,<2`, `n24q02m-mcp-core[llm]>=1.23.1,<2`, and `n24q02m-web-core>=2.5.0,<3` with regenerated lock
- clean-cut removal of the legacy QWEN3 cache alias
- focused manifest, cache, embedding, reranking, and pin regressions

## Verification
- focused pytest contracts: 32 passed
- Ruff on changed Python: passed
- `uv lock --check`: passed

Forward-only; no published tag is rewritten.