### PR TITLE
feat: expose search backend selection metadata

### DIFF
--- a/src/wet_mcp/docs/search.md
+++ b/src/wet_mcp/docs/search.md
@@ -5,7 +5,7 @@ Search the web, academic papers, or library documentation.
 ## Actions
 
 ### search
-Web search via SearXNG metasearch engine.
+Web search via the configured `SEARCH_BACKENDS` chain (for example, `searxng,jina`).
 
 **Parameters:**
 - `query` (required): Search query string
@@ -20,6 +20,10 @@ Web search via SearXNG metasearch engine.
 - `enrich`: Fetch actual page content for better snippets (default: false, adds 2-5s latency)
 
 Results are semantically reranked for better relevance. Duplicate URLs are normalized (tracking params stripped) and limited to 3 per domain.
+
+Every response includes a `search_backend` trace with the requested and attempted
+backend names, the selected backend, and a `fallback` result (`none`, `used`,
+`exhausted`, or `unavailable`).
 
 **Example:**
 ```json

--- a/src/wet_mcp/sources/search_backends.py
+++ b/src/wet_mcp/sources/search_backends.py
@@ -25,6 +25,8 @@ from wet_mcp.config import settings
 
 
 class SearchBackend(Protocol):
+    name: str
+
     async def search(
         self,
         query: str,
@@ -74,6 +76,8 @@ async def _search_with_rotation(
 
 
 class SearxngBackend:
+    name = "searxng"
+
     def __init__(self, url: str) -> None:
         self.url = url
 
@@ -102,6 +106,8 @@ class SearxngBackend:
 
 
 class TavilyBackend:
+    name = "tavily"
+
     _URL = "https://api.tavily.com/search"
 
     def __init__(self, keys: list[str]) -> None:
@@ -159,6 +165,8 @@ class BraveBackend:
     GET with header ``X-Subscription-Token``; results live at ``web.results[]``
     (verified against current Brave docs 2026-06-19).
     """
+
+    name = "brave"
 
     _URL = "https://api.search.brave.com/res/v1/web/search"
 
@@ -224,6 +232,8 @@ class ExaBackend:
     ``contents.text`` request so each result carries a snippet. Results live at
     ``results[]`` (verified against current Exa docs 2026-06-19).
     """
+
+    name = "exa"
 
     _URL = "https://api.exa.ai/search"
 
@@ -410,29 +420,44 @@ async def run_search_chain(
     categories="general",
     searxng_url: str | None = None,
 ) -> str:
-    """Run the SEARCH_BACKENDS chain with runtime fallback.
+    """Run the configured search chain and report the selected backend.
 
-    Tries each backend in order; on a raised error OR an empty/error result it
-    advances to the next, returning the first non-empty result (the shared
-    ``mcp_core.chains.run_with_fallback`` primitive). Returns an empty-results
-    envelope when every backend is exhausted. ``searxng_url`` is the live
-    auto-started SearXNG URL (when SearXNG is in the chain).
+    Providers are tried in order. Errors and empty results advance the chain.
+    The returned envelope records requested, attempted, selected, and fallback
+    state without exposing provider credentials or endpoints.
     """
+    requested = chain_backend_names()
     backends = search_backends_from_env(searxng_url)
     if not backends:
-        requested = chain_backend_names()
         msg = (
             f"Search backends {requested} are missing API keys; configure a key or add searxng"
             if requested
             else "No search backend configured"
         )
         return json.dumps(
-            {"results": [], "total": 0, "query": query, "error": msg},
+            {
+                "results": [],
+                "total": 0,
+                "query": query,
+                "error": msg,
+                "search_backend": {
+                    "requested": requested,
+                    "attempted": [],
+                    "selected": None,
+                    "fallback": "unavailable",
+                },
+            },
             ensure_ascii=False,
         )
-    thunks = [
-        (
-            lambda b=b: b.search(
+
+    attempted: list[str] = []
+    selected: str | None = None
+
+    def traced_thunk(backend: SearchBackend) -> Callable[[], Awaitable[str]]:
+        async def invoke() -> str:
+            nonlocal selected
+            attempted.append(backend.name)
+            payload = await backend.search(
                 query=query,
                 max_results=max_results,
                 time_range=time_range,
@@ -441,21 +466,36 @@ async def run_search_chain(
                 exclude_domains=exclude_domains,
                 categories=categories,
             )
-        )
-        for b in backends
-    ]
+            if not _search_result_is_empty(payload):
+                selected = backend.name
+            return payload
+
+        return invoke
+
     result = await run_with_fallback(
-        thunks,
+        [traced_thunk(backend) for backend in backends],
         is_empty=_search_result_is_empty,
         on_error=lambda idx, exc: logger.warning(
             f"Search backend #{idx} raised: {type(exc).__name__}"
         ),
     )
-    if result is None:
-        return json.dumps(
-            {"results": [], "total": 0, "query": query}, ensure_ascii=False
-        )
-    return result
+
+    data: dict[str, object] = (
+        json.loads(result)
+        if result is not None
+        else {"results": [], "total": 0, "query": query}
+    )
+    data["search_backend"] = {
+        "requested": requested,
+        "attempted": attempted,
+        "selected": selected,
+        "fallback": (
+            "exhausted"
+            if selected is None
+            else ("none" if requested and selected == requested[0] else "used")
+        ),
+    }
+    return json.dumps(data, ensure_ascii=False)
 
 
 __all__ = [

--- a/tests/test_live_protocol.py
+++ b/tests/test_live_protocol.py
@@ -9,7 +9,10 @@ Usage:
 
 import json
 import os
+import subprocess
 import warnings
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
 
 import pytest
 from mcp import StdioServerParameters
@@ -37,25 +40,132 @@ def parse_allow_error(r) -> str:
     return r.content[0].text
 
 
+class _SearxngHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        if self.path.startswith("/healthz"):
+            payload_data: dict = {"status": "ok"}
+        elif self.path.startswith("/search"):
+            payload_data = {
+                "results": [
+                    {
+                        "url": f"https://example.com/python-testing-{index}",
+                        "title": f"Python testing result {index}",
+                        "content": (
+                            "Deterministic Python testing guidance for the "
+                            f"foundation live protocol fixture {index}."
+                        ),
+                        "engine": "fixture",
+                    }
+                    for index in range(12)
+                ]
+            }
+        else:
+            self.send_error(404)
+            return
+
+        body = json.dumps(payload_data).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@pytest.fixture(scope="module")
+def searxng_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SearxngHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host = server.server_address[0]
+        port = server.server_address[1]
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-async def mcp_session():
-    """Start real wet-mcp server via stdio, yield ClientSession.
+async def mcp_session(searxng_server: str, tmp_path):
+    """Start a real local-only wet-mcp server via stdio."""
+    from fastretrieval import define_cache_dir
 
-    Suppresses anyio cancel-scope teardown errors that occur when
-    pytest-asyncio tears down the event loop in a different task context.
-    """
+    local_state = tmp_path / "local-state"
+    local_env = {
+        **os.environ,
+        "LOG_LEVEL": "WARNING",
+        "MCP_TRANSPORT": "stdio",
+        "HOME": str(local_state),
+        "USERPROFILE": str(local_state),
+        "XDG_CONFIG_HOME": str(local_state),
+        "LOCALAPPDATA": str(local_state),
+        "APPDATA": str(local_state),
+        "CACHE_DIR": str(tmp_path),
+        "DOCS_DB_PATH": str(tmp_path / "docs.db"),
+        "FASTRETRIEVAL_CACHE_PATH": str(define_cache_dir()),
+        "QWEN3_EMBED_CACHE_PATH": "",
+        "SYNC_ENABLED": "false",
+        "GOOGLE_DRIVE_CLIENT_ID": "",
+        "API_KEYS": "",
+        "JINA_API_KEY": "",
+        "JINA_AI_API_KEY": "",
+        "GEMINI_API_KEY": "",
+        "GOOGLE_API_KEY": "",
+        "OPENAI_API_KEY": "",
+        "COHERE_API_KEY": "",
+        "CO_API_KEY": "",
+        "ANTHROPIC_API_KEY": "",
+        "XAI_API_KEY": "",
+        "GOOGLE_VERTEX_EXPRESS_API_KEY": "",
+        "TAVILY_API_KEY": "",
+        "BRAVE_API_KEY": "",
+        "EXA_API_KEY": "",
+        "EMBEDDING_MODELS": "",
+        "RERANK_MODELS": "",
+        "LLM_MODELS": "",
+        "EMBEDDING_MODEL": "",
+        "RERANK_MODEL": "",
+        "EMBEDDING_BACKEND": "",
+        "RERANK_BACKEND": "",
+        "EMBEDDING_API_BASE": "",
+        "RERANK_API_BASE": "",
+        "LLM_API_BASE": "",
+        "LOCAL_EMBEDDING_MODEL": "",
+        "LOCAL_RERANK_MODEL": "",
+        "EMBEDDING_DIMS": "0",
+        "RERANK_ENABLED": "true",
+        "DISABLE_LOCAL_EMBED": "false",
+        "DISABLE_LOCAL_RERANK": "false",
+        "SEARCH_BACKENDS": "searxng",
+        "SEARXNG_URL": searxng_server,
+        "WET_AUTO_SEARXNG": "false",
+    }
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-c",
+            "from mcp_core import set_local_mode; set_local_mode('wet-mcp')",
+        ],
+        env=local_env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     server_params = StdioServerParameters(
         command="uv",
         args=["run", "wet-mcp"],
-        env={
-            **os.environ,
-            "LOG_LEVEL": "WARNING",
-        },
+        env=local_env,
     )
     try:
         async with stdio_client(server_params) as (read_stream, write_stream):
@@ -121,6 +231,7 @@ class TestHelp:
 
 
 class TestConfig:
+    @pytest.mark.timeout(300)
     async def test_config_status(self, mcp_session: ClientSession):
         r = await mcp_session.call_tool("config", {"action": "status"})
         text = parse(r)
@@ -156,6 +267,19 @@ class TestConfig:
         assert isinstance(reranker["backend"], (str, type(None)))
         assert isinstance(reranker["model"], (str, type(None)))
         assert isinstance(reranker["available"], bool)
+        assert embedding["available"] is True
+        assert embedding["backend"] == "LocalEmbeddingBackend"
+        assert embedding["model"] in {
+            "n24q02m/Qwen3-Embedding-0.6B-ONNX",
+            "n24q02m/Qwen3-Embedding-0.6B-GGUF",
+        }
+        assert embedding["dims"] == 768
+        assert reranker["available"] is True
+        assert reranker["backend"] == "LocalReranker"
+        assert reranker["model"] in {
+            "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo",
+            "n24q02m/Qwen3-Reranker-0.6B-GGUF",
+        }
 
     async def test_config_set(self, mcp_session: ClientSession):
         r = await mcp_session.call_tool(
@@ -296,18 +420,14 @@ class TestSearch:
         )
         data = payload(r)
         assert data["_untrusted_source"] == "web"
-        results = data.get("results")
-        if isinstance(results, list) and results:
-            return
-
-        error = data.get("error")
-        assert isinstance(error, str) and error.strip()
-        error_lower = error.lower()
-        assert (
-            "needs a search backend" in error_lower
-            or "no search backend configured" in error_lower
-            or ("search backends" in error_lower and "missing api key" in error_lower)
-        ), f"Unexpected search response: {data}"
+        results = data["results"]
+        assert isinstance(results, list) and results
+        assert data["search_backend"] == {
+            "requested": ["searxng"],
+            "attempted": ["searxng"],
+            "selected": "searxng",
+            "fallback": "none",
+        }
 
     async def test_search_research(self, mcp_session: ClientSession):
         r = await mcp_session.call_tool(

--- a/tests/test_search_backends.py
+++ b/tests/test_search_backends.py
@@ -206,6 +206,7 @@ def test_search_result_is_empty_predicate():
 
 
 async def test_run_search_chain_falls_back_on_empty(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "searxng,brave")
     # First backend returns empty, second returns a hit -> second wins.
     empty = unittest.mock.AsyncMock(
         return_value='{"results": [], "total": 0, "query": "q"}'
@@ -214,8 +215,10 @@ async def test_run_search_chain_falls_back_on_empty(monkeypatch):
         return_value='{"results": [{"url": "https://h/1"}], "total": 1, "query": "q"}'
     )
     b0 = unittest.mock.Mock()
+    b0.name = "searxng"
     b0.search = empty
     b1 = unittest.mock.Mock()
+    b1.name = "brave"
     b1.search = hit
     with unittest.mock.patch(
         "wet_mcp.sources.search_backends.search_backends_from_env",
@@ -223,8 +226,41 @@ async def test_run_search_chain_falls_back_on_empty(monkeypatch):
     ):
         out = json.loads(await run_search_chain("q"))
         assert out["results"][0]["url"] == "https://h/1"
+        assert out["search_backend"] == {
+            "requested": ["searxng", "brave"],
+            "attempted": ["searxng", "brave"],
+            "selected": "brave",
+            "fallback": "used",
+        }
         empty.assert_awaited()
         hit.assert_awaited()
+
+
+async def test_run_search_chain_reports_skipped_configured_backend_as_fallback(
+    monkeypatch,
+):
+    monkeypatch.setenv("SEARCH_BACKENDS", "brave,searxng")
+
+    async def hit(**_kwargs):
+        return json.dumps(
+            {"results": [{"url": "https://h/1"}], "total": 1, "query": "q"}
+        )
+
+    backend = unittest.mock.Mock()
+    backend.name = "searxng"
+    backend.search = hit
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[backend],
+    ):
+        out = json.loads(await run_search_chain("q"))
+
+    assert out["search_backend"] == {
+        "requested": ["brave", "searxng"],
+        "attempted": ["searxng"],
+        "selected": "searxng",
+        "fallback": "used",
+    }
 
 
 async def test_run_search_chain_empty_when_no_backends(monkeypatch):
@@ -237,3 +273,9 @@ async def test_run_search_chain_empty_when_no_backends(monkeypatch):
     out = json.loads(await run_search_chain("q"))
     assert out["results"] == []
     assert "brave" in out["error"]
+    assert out["search_backend"] == {
+        "requested": ["brave"],
+        "attempted": [],
+        "selected": None,
+        "fallback": "unavailable",
+    }


### PR DESCRIPTION
## Change
- return requested, attempted, selected, and fallback search-backend metadata
- report skipped configured backends as a real fallback, not `none`
- isolate live protocol tests from native config/provider keys and use a deterministic local SearXNG stub
- assert local Fastretrieval model identities and 768 dimensions from config status
- document the public response trace

## Verification
- search backend unit tests: 18 passed
- exact isolated live config/search nodes: 2 passed
- full pytest via scoped pre-commit: passed
- Ruff, format, ty, uv lock, and scoped pre-commit: passed

Review state: REVIEW-DEGRADED-PROVIDER-QUOTA; parent and local graph review found no blocking issue.