### PR TITLE
fix: reuse search chain in agent extraction

### DIFF
--- a/src/wet_mcp/sources/agent_orchestrator.py
+++ b/src/wet_mcp/sources/agent_orchestrator.py
@@ -18,6 +18,7 @@ from typing import Any
 from loguru import logger
 
 from wet_mcp.credential_state import LLM_PROVIDER_KEYS
+from wet_mcp.sources.search_backends import run_search_chain
 
 # LLM-provider key env names, in spec-section-5.6 fallback priority. The
 # canonical list now lives in ``credential_state.LLM_PROVIDER_KEYS`` so the
@@ -179,32 +180,34 @@ async def run_agent(
 
     max_urls = _clamp_max_urls(max_urls)
 
-    # 1. Search round.
-    from wet_mcp.config import settings
-    from wet_mcp.sources.searxng import search as searxng_search
-
+    # 1. Search round through the canonical provider chain.
     try:
-        raw_search = await searxng_search(
-            settings.searxng_url, query, max_results=max_urls
-        )
+        raw_search = await run_search_chain(query, max_results=max_urls)
         search_payload = json.loads(raw_search)
+        if not isinstance(search_payload, dict):
+            raise ValueError("search returned a non-object payload")
     except Exception as exc:
-        logger.error(f"agent_orchestrator search failed: {exc}")
-        return f"Error: search failed: {exc}"
+        error_type = type(exc).__name__
+        logger.error(f"agent_orchestrator search failed: {error_type}")
+        return f"Error: search failed: {error_type}"
 
-    raw_results = (
-        search_payload.get("results", [])
-        if isinstance(search_payload, dict)
-        else search_payload
-    )
-    urls = [r.get("url") for r in raw_results if isinstance(r, dict) and r.get("url")][
-        :max_urls
-    ]
+    if search_payload.get("error"):
+        return f"Error: search failed: {search_payload['error']}"
+
+    raw_results = search_payload.get("results", [])
+    if not isinstance(raw_results, list):
+        return "Error: search failed: results is not a list"
+    selected_results = [
+        result
+        for result in raw_results
+        if isinstance(result, dict) and result.get("url")
+    ][:max_urls]
+    urls = [str(result["url"]) for result in selected_results]
     if not urls:
         return {
             "markdown": (
                 f"No results found for query: {query!r}. Try a different "
-                "phrasing or use search(action='research') for academic queries."
+                f"phrasing or use search(action='research') for academic queries."
             ),
             "sources": [],
             "per_url_metadata": [],
@@ -223,32 +226,42 @@ async def run_agent(
         logger.error(f"agent_orchestrator synthesis failed: {exc}")
         return f"Error: synthesis failed: {exc}"
 
-    sources = [
-        {
-            "index": i + 1,
-            "url": extract.get("url", urls[i] if i < len(urls) else ""),
-            "title": (extract.get("metadata") or {}).get("title")
-            or extract.get("title", ""),
-        }
-        for i, extract in enumerate(extracts)
-    ]
-    per_url_metadata = [
-        {
-            "url": extract.get("url", urls[i] if i < len(urls) else ""),
-            "extract_strategy": (extract.get("metadata") or {}).get(
-                "scrape_strategy_used", ""
-            ),
-            "tokens": len(
-                extract.get("markdown")
-                or extract.get("clean_text")
-                or extract.get("content")
-                or ""
-            )
-            // _CHARS_PER_TOKEN,
-            "error": extract.get("error"),
-        }
-        for i, extract in enumerate(extracts)
-    ]
+    sources = []
+    for i, extract in enumerate(extracts):
+        search_result = selected_results[i] if i < len(selected_results) else {}
+        search_provider = str(search_result.get("source") or "")
+        sources.append(
+            {
+                "index": i + 1,
+                "url": extract.get("url", urls[i] if i < len(urls) else ""),
+                "title": (extract.get("metadata") or {}).get("title")
+                or extract.get("title")
+                or search_result.get("title", ""),
+                "search_provider": search_provider,
+            }
+        )
+
+    per_url_metadata = []
+    for i, extract in enumerate(extracts):
+        search_result = selected_results[i] if i < len(selected_results) else {}
+        search_provider = str(search_result.get("source") or "")
+        per_url_metadata.append(
+            {
+                "url": extract.get("url", urls[i] if i < len(urls) else ""),
+                "extract_strategy": (extract.get("metadata") or {}).get(
+                    "scrape_strategy_used", ""
+                ),
+                "tokens": len(
+                    extract.get("markdown")
+                    or extract.get("clean_text")
+                    or extract.get("content")
+                    or ""
+                )
+                // _CHARS_PER_TOKEN,
+                "error": extract.get("error"),
+                "search_provider": search_provider,
+            }
+        )
 
     return {
         "markdown": markdown,

--- a/src/wet_mcp/sources/search_backends.py
+++ b/src/wet_mcp/sources/search_backends.py
@@ -398,7 +398,7 @@ def search_backends_from_env(searxng_url: str | None = None) -> list[SearchBacke
 
 def _search_result_is_empty(payload: str) -> bool:
     """A search result JSON string counts as empty (advance the chain) when it
-    is an error envelope or carries no results."""
+    is an error envelope, malformed, or carries no results."""
     try:
         data = json.loads(payload)
     except (json.JSONDecodeError, TypeError):
@@ -407,7 +407,23 @@ def _search_result_is_empty(payload: str) -> bool:
         return True
     if data.get("error"):
         return True
-    return not data.get("results")
+    results = data.get("results")
+    if not isinstance(results, list):
+        return True
+    return not results
+
+
+def _search_result_has_failure(payload: str) -> bool:
+    """Return whether a provider outcome is an error or malformed payload."""
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return True
+    return not (
+        isinstance(data, dict)
+        and not data.get("error")
+        and isinstance(data.get("results"), list)
+    )
 
 
 async def run_search_chain(
@@ -452,21 +468,28 @@ async def run_search_chain(
 
     attempted: list[str] = []
     selected: str | None = None
+    had_provider_failure = False
 
     def traced_thunk(backend: SearchBackend) -> Callable[[], Awaitable[str]]:
         async def invoke() -> str:
-            nonlocal selected
+            nonlocal had_provider_failure, selected
             attempted.append(backend.name)
-            payload = await backend.search(
-                query=query,
-                max_results=max_results,
-                time_range=time_range,
-                language=language,
-                include_domains=include_domains,
-                exclude_domains=exclude_domains,
-                categories=categories,
-            )
-            if not _search_result_is_empty(payload):
+            try:
+                payload = await backend.search(
+                    query=query,
+                    max_results=max_results,
+                    time_range=time_range,
+                    language=language,
+                    include_domains=include_domains,
+                    exclude_domains=exclude_domains,
+                    categories=categories,
+                )
+            except Exception:
+                had_provider_failure = True
+                raise
+            if _search_result_has_failure(payload):
+                had_provider_failure = True
+            elif not _search_result_is_empty(payload):
                 selected = backend.name
             return payload
 
@@ -485,6 +508,8 @@ async def run_search_chain(
         if result is not None
         else {"results": [], "total": 0, "query": query}
     )
+    if selected is None and had_provider_failure:
+        data["error"] = "Search backend chain exhausted after provider failure"
     data["search_backend"] = {
         "requested": requested,
         "attempted": attempted,

--- a/tests/test_extract_agent.py
+++ b/tests/test_extract_agent.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -25,8 +25,368 @@ def _gemini_env(monkeypatch):
 
 def _make_search_payload(urls: list[str]) -> str:
     return json.dumps(
-        {"results": [{"url": u, "title": f"Title for {u}"} for u in urls]}
+        {
+            "results": [
+                {
+                    "url": u,
+                    "title": f"Title for {u}",
+                    "snippet": f"Snippet for {u}",
+                    "source": "searxng",
+                }
+                for u in urls
+            ]
+        }
     )
+
+
+@pytest.mark.asyncio
+async def test_agent_uses_later_search_backend_and_keeps_provenance(
+    _gemini_env,
+) -> None:
+    first = MagicMock(name="searxng")
+    first.name = "searxng"
+    first.search = AsyncMock(
+        return_value=json.dumps({"results": [], "total": 0, "query": "q"})
+    )
+    second = MagicMock(name="brave")
+    second.name = "brave"
+    second.search = AsyncMock(
+        return_value=json.dumps(
+            {
+                "results": [
+                    {
+                        "url": "https://example.com/hit",
+                        "title": "Selected title",
+                        "snippet": "Selected snippet",
+                        "source": "brave",
+                    }
+                ],
+                "total": 1,
+                "query": "q",
+            }
+        )
+    )
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.search_backends_from_env",
+            return_value=[first, second],
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(side_effect=AssertionError("direct SearXNG call")),
+        ),
+        patch(
+            "wet_mcp.sources.crawler.extract",
+            new=AsyncMock(
+                return_value=_make_extract_payload("https://example.com/hit")
+            ),
+        ),
+        patch.object(ao, "_llm_synthesize", new=AsyncMock(return_value="answer [1]")),
+    ):
+        result = await ao.run_agent("q", max_urls=1)
+
+    assert isinstance(result, dict)
+    assert result["sources"] == [
+        {
+            "index": 1,
+            "url": "https://example.com/hit",
+            "title": "Title for https://example.com/hit",
+            "search_provider": "brave",
+        }
+    ]
+    assert result["per_url_metadata"][0]["search_provider"] == "brave"
+
+
+@pytest.mark.asyncio
+async def test_agent_uses_later_search_backend_after_error(_gemini_env) -> None:
+    first = MagicMock(name="searxng")
+    first.name = "searxng"
+    first.search = AsyncMock(side_effect=RuntimeError("first backend down"))
+    second = MagicMock(name="brave")
+    second.name = "brave"
+    second.search = AsyncMock(
+        return_value=json.dumps(
+            {
+                "results": [
+                    {
+                        "url": "https://example.com/hit",
+                        "title": "Selected title",
+                        "snippet": "Selected snippet",
+                        "source": "brave",
+                    }
+                ],
+                "total": 1,
+                "query": "q",
+            }
+        )
+    )
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.search_backends_from_env",
+            return_value=[first, second],
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(side_effect=AssertionError("direct SearXNG call")),
+        ),
+        patch(
+            "wet_mcp.sources.crawler.extract",
+            new=AsyncMock(
+                return_value=_make_extract_payload("https://example.com/hit")
+            ),
+        ),
+        patch.object(ao, "_llm_synthesize", new=AsyncMock(return_value="answer [1]")),
+    ):
+        result = await ao.run_agent("q", max_urls=1)
+
+    assert isinstance(result, dict)
+    assert result["sources"][0]["search_provider"] == "brave"
+    assert result["per_url_metadata"][0]["search_provider"] == "brave"
+
+
+@pytest.mark.asyncio
+async def test_agent_all_empty_search_keeps_no_results_contract(_gemini_env):
+    first = MagicMock(name="searxng")
+    first.name = "searxng"
+    first.search = AsyncMock(
+        return_value=json.dumps({"results": [], "total": 0, "query": "q"})
+    )
+    second = MagicMock(name="brave")
+    second.name = "brave"
+    second.search = AsyncMock(
+        return_value=json.dumps({"results": [], "total": 0, "query": "q"})
+    )
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.search_backends_from_env",
+            return_value=[first, second],
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(side_effect=AssertionError("direct SearXNG call")),
+        ),
+    ):
+        result = await ao.run_agent("q")
+
+    assert isinstance(result, dict)
+    assert result["sources"] == []
+    assert result["per_url_metadata"] == []
+    assert "No results found" in result["markdown"]
+
+
+@pytest.mark.asyncio
+async def test_agent_all_failed_search_is_hard_failure(_gemini_env):
+    first = MagicMock(name="searxng")
+    first.name = "searxng"
+    first.search = AsyncMock(side_effect=RuntimeError("first backend down"))
+    second = MagicMock(name="brave")
+    second.name = "brave"
+    second.search = AsyncMock(side_effect=RuntimeError("second backend down"))
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.search_backends_from_env",
+            return_value=[first, second],
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(side_effect=AssertionError("direct SearXNG call")),
+        ),
+    ):
+        result = await ao.run_agent("q")
+
+    assert result == (
+        "Error: search failed: Search backend chain exhausted after provider failure"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_uses_later_search_backend_after_malformed_results(_gemini_env):
+    first = MagicMock(name="searxng")
+    first.name = "searxng"
+    first.search = AsyncMock(
+        return_value=json.dumps({"results": "not-a-list", "total": 1, "query": "q"})
+    )
+    second = MagicMock(name="brave")
+    second.name = "brave"
+    second.search = AsyncMock(
+        return_value=json.dumps(
+            {
+                "results": [
+                    {
+                        "url": "https://example.com/hit",
+                        "title": "Selected title",
+                        "snippet": "Selected snippet",
+                        "source": "brave",
+                    }
+                ],
+                "total": 1,
+                "query": "q",
+            }
+        )
+    )
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.search_backends_from_env",
+            return_value=[first, second],
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(side_effect=AssertionError("direct SearXNG call")),
+        ),
+        patch(
+            "wet_mcp.sources.crawler.extract",
+            new=AsyncMock(
+                return_value=_make_extract_payload("https://example.com/hit")
+            ),
+        ),
+        patch.object(ao, "_llm_synthesize", new=AsyncMock(return_value="answer [1]")),
+    ):
+        result = await ao.run_agent("q", max_urls=1)
+
+    assert isinstance(result, dict)
+    assert result["sources"][0]["search_provider"] == "brave"
+    assert result["per_url_metadata"][0]["search_provider"] == "brave"
+
+
+@pytest.mark.asyncio
+async def test_agent_preserves_multi_result_order_and_search_title_fallback(
+    _gemini_env,
+):
+    first_url = "https://example.com/first"
+    second_url = "https://example.com/second"
+    first = MagicMock(name="brave")
+    first.name = "brave"
+    first.search = AsyncMock(
+        return_value=json.dumps(
+            {
+                "results": [
+                    {
+                        "url": first_url,
+                        "title": "Search title one",
+                        "snippet": "Search snippet one",
+                        "source": "brave",
+                    },
+                    {
+                        "url": second_url,
+                        "title": "Search title two",
+                        "snippet": "Search snippet two",
+                        "source": "exa",
+                    },
+                ],
+                "total": 2,
+                "query": "q",
+            }
+        )
+    )
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.search_backends_from_env",
+            return_value=[first],
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(side_effect=AssertionError("direct SearXNG call")),
+        ),
+        patch(
+            "wet_mcp.sources.crawler.extract",
+            new=AsyncMock(
+                side_effect=[
+                    _make_extract_payload(first_url, "First body"),
+                    json.dumps(
+                        [
+                            {
+                                "url": second_url,
+                                "markdown": "Second body",
+                                "metadata": {"scrape_strategy_used": "basic_http"},
+                            }
+                        ]
+                    ),
+                ]
+            ),
+        ),
+        patch.object(
+            ao, "_llm_synthesize", new=AsyncMock(return_value="answer [1] [2]")
+        ),
+    ):
+        result = await ao.run_agent("q", max_urls=2)
+
+    assert isinstance(result, dict)
+    assert result["sources"] == [
+        {
+            "index": 1,
+            "url": first_url,
+            "title": f"Title for {first_url}",
+            "search_provider": "brave",
+        },
+        {
+            "index": 2,
+            "url": second_url,
+            "title": "Search title two",
+            "search_provider": "exa",
+        },
+    ]
+    assert [
+        (row["url"], row["search_provider"]) for row in result["per_url_metadata"]
+    ] == [(first_url, "brave"), (second_url, "exa")]
+
+
+@pytest.mark.asyncio
+async def test_agent_search_error_envelope_is_hard_failure(_gemini_env) -> None:
+    error_payload = json.dumps({"results": [], "error": "unavailable"})
+    with (
+        patch.object(
+            ao,
+            "run_search_chain",
+            new=AsyncMock(return_value=error_payload),
+            create=True,
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(return_value=error_payload),
+        ),
+    ):
+        result = await ao.run_agent("q")
+    assert result == "Error: search failed: unavailable"
+
+
+@pytest.mark.asyncio
+async def test_agent_invalid_search_payload_is_hard_failure(_gemini_env) -> None:
+    with (
+        patch.object(
+            ao,
+            "run_search_chain",
+            new=AsyncMock(return_value="not json"),
+            create=True,
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(return_value="not json"),
+        ),
+    ):
+        result = await ao.run_agent("q")
+    assert result == "Error: search failed: JSONDecodeError"
+
+
+@pytest.mark.asyncio
+async def test_agent_legitimate_empty_search_keeps_no_results_contract(_gemini_env):
+    empty_payload = json.dumps({"results": [], "total": 0, "query": "q"})
+    with (
+        patch.object(
+            ao,
+            "run_search_chain",
+            new=AsyncMock(return_value=empty_payload),
+            create=True,
+        ),
+        patch(
+            "wet_mcp.sources.searxng.search",
+            new=AsyncMock(return_value=empty_payload),
+        ),
+    ):
+        result = await ao.run_agent("q")
+    assert isinstance(result, dict)
+    assert result["sources"] == []
+    assert result["per_url_metadata"] == []
+    assert "No results found" in result["markdown"]
 
 
 def _make_extract_payload(url: str, body: str = "Body content") -> str:
@@ -64,8 +424,9 @@ async def test_empty_query_returns_error(_gemini_env) -> None:
 async def test_pipeline_search_then_extract_then_synthesize(_gemini_env) -> None:
     urls = [f"https://example.com/{i}" for i in range(5)]
     with (
-        patch(
-            "wet_mcp.sources.searxng.search",
+        patch.object(
+            ao,
+            "run_search_chain",
             new_callable=AsyncMock,
             return_value=_make_search_payload(urls),
         ),
@@ -134,10 +495,11 @@ async def test_synthesis_prompt_includes_numbered_citations(_gemini_env) -> None
 
 @pytest.mark.asyncio
 async def test_search_failure_returns_error_string(_gemini_env) -> None:
-    with patch(
-        "wet_mcp.sources.searxng.search",
+    with patch.object(
+        ao,
+        "run_search_chain",
         new_callable=AsyncMock,
-        side_effect=RuntimeError("searxng down"),
+        return_value=json.dumps({"results": [], "error": "unavailable"}),
     ):
         result = await ao.run_agent(query="x")
     assert isinstance(result, str)
@@ -146,8 +508,9 @@ async def test_search_failure_returns_error_string(_gemini_env) -> None:
 
 @pytest.mark.asyncio
 async def test_no_search_results_returns_empty_synthesis(_gemini_env) -> None:
-    with patch(
-        "wet_mcp.sources.searxng.search",
+    with patch.object(
+        ao,
+        "run_search_chain",
         new_callable=AsyncMock,
         return_value=json.dumps({"results": []}),
     ):
@@ -161,8 +524,9 @@ async def test_no_search_results_returns_empty_synthesis(_gemini_env) -> None:
 async def test_synthesis_failure_returns_error_string(_gemini_env) -> None:
     urls = ["https://example.com/1"]
     with (
-        patch(
-            "wet_mcp.sources.searxng.search",
+        patch.object(
+            ao,
+            "run_search_chain",
             new_callable=AsyncMock,
             return_value=_make_search_payload(urls),
         ),
@@ -186,8 +550,9 @@ async def test_synthesis_failure_returns_error_string(_gemini_env) -> None:
 async def test_extract_error_propagates_to_per_url_metadata(_gemini_env) -> None:
     urls = ["https://broken.com/1"]
     with (
-        patch(
-            "wet_mcp.sources.searxng.search",
+        patch.object(
+            ao,
+            "run_search_chain",
             new_callable=AsyncMock,
             return_value=_make_search_payload(urls),
         ),

--- a/tests/test_search_backends.py
+++ b/tests/test_search_backends.py
@@ -236,6 +236,72 @@ async def test_run_search_chain_falls_back_on_empty(monkeypatch):
         hit.assert_awaited()
 
 
+async def test_run_search_chain_all_empty_is_legitimate_empty(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "searxng,brave")
+    empty = unittest.mock.AsyncMock(
+        return_value='{"results": [], "total": 0, "query": "q"}'
+    )
+    b0 = unittest.mock.Mock()
+    b0.name = "searxng"
+    b0.search = empty
+    b1 = unittest.mock.Mock()
+    b1.name = "brave"
+    b1.search = empty
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[b0, b1],
+    ):
+        out = json.loads(await run_search_chain("q"))
+
+    assert out["results"] == []
+    assert "error" not in out
+    assert out["search_backend"]["fallback"] == "exhausted"
+
+
+async def test_run_search_chain_reports_error_when_all_backends_fail(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "searxng,brave")
+    failed = unittest.mock.AsyncMock(side_effect=RuntimeError("provider down"))
+    b0 = unittest.mock.Mock()
+    b0.name = "searxng"
+    b0.search = failed
+    b1 = unittest.mock.Mock()
+    b1.name = "brave"
+    b1.search = failed
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[b0, b1],
+    ):
+        out = json.loads(await run_search_chain("q"))
+
+    assert out["results"] == []
+    assert out["error"] == "Search backend chain exhausted after provider failure"
+
+
+async def test_run_search_chain_advances_past_non_list_results(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "searxng,brave")
+    malformed = unittest.mock.AsyncMock(
+        return_value='{"results": "not-a-list", "total": 1, "query": "q"}'
+    )
+    hit = unittest.mock.AsyncMock(
+        return_value='{"results": [{"url": "https://h/1"}], "total": 1, "query": "q"}'
+    )
+    b0 = unittest.mock.Mock()
+    b0.name = "searxng"
+    b0.search = malformed
+    b1 = unittest.mock.Mock()
+    b1.name = "brave"
+    b1.search = hit
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[b0, b1],
+    ):
+        out = json.loads(await run_search_chain("q"))
+
+    assert out["results"][0]["url"] == "https://h/1"
+    assert out["search_backend"]["selected"] == "brave"
+    assert out["search_backend"]["fallback"] == "used"
+
+
 async def test_run_search_chain_reports_skipped_configured_backend_as_fallback(
     monkeypatch,
 ):


### PR DESCRIPTION
## Spec

Implements approved Phase 2 design §6 (canonical search chain inside the existing agent composite) and §7 review boundary.

## Change

- route `run_agent` through canonical `run_search_chain` instead of direct SearXNG
- preserve selected-result ordering/title/provenance in `sources` and `per_url_metadata`
- distinguish legitimate all-valid-empty exhaustion from provider-error/malformed exhaustion
- retain later-provider success and explicit safe hard-error envelopes

## Verification

- focused agent/dispatch/backend suite — 45 passed
- Ruff check/format-check and `ty check` on changed paths — passed
- `uv run pytest -q` — 2443 passed, 33 skipped, 140 deselected; post-type-narrowing pre-commit pytest also passed
- pre-commit gitleaks/Ruff/ty/pytest/Unicode gates — passed
- behavioral smoke — raised first backend fell through to Brave with aligned provenance; valid-empty remained error-free; failure exhaustion returned the exact safe error
- final cross-repository review — spec PASS; no Critical/Important finding; final coverage P3 re-review ADDRESSED

## Non-goals

No new MCP tool/action, provider/OAuth route, environment rename, cross-repository orchestration, broker/ACP work, or stable promotion.

## Rollback

Revert this PR's squash commit; existing provider-chain configuration remains unchanged.