### PR TITLE
feat: optional region filter and bounded refine loop for web search

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -7,6 +7,7 @@ import functools
 import io
 import json
 import os
+import re
 import sys
 import time
 
@@ -62,6 +63,10 @@ logger.add(sys.stderr, level=settings.log_level)
 # yields an incompatible vector space -- DocsDB's embedding-model identity
 # guard (B2) catches that. Override via EMBEDDING_DIMS env var.
 _DEFAULT_EMBEDDING_DIMS = 768
+
+
+# ``region`` (search action): 2-letter ISO 3166-1 alpha-2 geo code.
+_REGION_RE = re.compile(r"^[A-Za-z]{2}$")
 
 # Reranking: retrieve more candidates than final limit, then rerank.
 _RERANK_CANDIDATE_MULTIPLIER = 3
@@ -1128,6 +1133,8 @@ async def search(  # noqa: PLR0913
     from_date: str | None = None,
     to_date: str | None = None,
     video: bool = False,
+    region: str | None = None,
+    refine: bool = False,
 ) -> dict[str, Any]:
     """Find information across web, academic sources, X/Twitter, or library docs. Returns search result listings (titles, URLs, snippets) -- NOT full page content. To read full content from a URL, use the `extract` tool instead.
 
@@ -1153,6 +1160,8 @@ async def search(  # noqa: PLR0913
     - handles / exclude_handles (x only): Restrict to / exclude up to 20 X handles (mutually exclusive), e.g. handles=["nasa"]
     - from_date / to_date (x only): ISO8601 date bounds; override time_range for precise windows
     - video (x only): Enable video understanding of linked X media (default: false)
+    - region (search only): 2-letter ISO 3166-1 country code (e.g. "US", "vn") geo filter. Backends without region support are skipped (named in a warning); a chain with no region-capable backend returns a structured error naming them.
+    - refine (search only): Opt-in iterative refinement. When results are empty or low-relevance, re-queries up to 2 times with LLM-rewritten terms and returns the best round (adds LLM latency/cost per round).
 
     Use `help` tool with tool_name="search" for full parameter documentation.
     """
@@ -1193,18 +1202,30 @@ async def search(  # noqa: PLR0913
                 }
             from wet_mcp.sources._search_polish import (
                 normalize_query,
+                refine_needed,
+                round_quality,
                 search_ttl_seconds,
                 standardize_results,
             )
 
             normalized_query = normalize_query(query)
             ttl = search_ttl_seconds(time_range)
+            region_normalized = region.strip() if isinstance(region, str) else ""
+            if region_normalized and not _REGION_RE.fullmatch(region_normalized):
+                return {
+                    "error": (
+                        f"Invalid region={region!r} for search action: expected "
+                        "a 2-letter ISO 3166-1 code (e.g. 'US', 'vn')."
+                    )
+                }
+            region_normalized = region_normalized.upper() or None
             cache_params = {
                 "query": normalized_query,
                 "categories": categories,
                 "max_results": max_results,
                 "time_range": time_range,
                 "language": language,
+                "region": region_normalized,
                 "include_domains": include_domains,
                 "exclude_domains": exclude_domains,
             }
@@ -1254,110 +1275,165 @@ async def search(  # noqa: PLR0913
                 except (SystemExit, Exception) as exc:
                     return {"error": f"Error: SearXNG startup failed: {exc}"}
 
-            result = await _with_timeout(
-                search_backends.run_search_chain(
-                    query=search_query,
-                    categories=categories,
-                    max_results=max_results * _RERANK_CANDIDATE_MULTIPLIER,
-                    time_range=time_range,
-                    language=language,
-                    include_domains=include_domains,
-                    exclude_domains=exclude_domains,
-                    searxng_url=live_searxng_url,
-                ),
-                "search",
-            )
-            if not result.startswith("Error"):
+            async def _round(round_query: str) -> tuple[str, dict[str, Any] | None]:
+                """One chain round: run the chain, sanity-filter, rerank.
+
+                Returns ``(raw_payload, parsed_envelope)``; ``data`` is
+                ``None`` when the chain itself failed (tool timeout or
+                unparseable payload) and the raw text must pass through.
+                """
+                result = await _with_timeout(
+                    search_backends.run_search_chain(
+                        query=round_query,
+                        categories=categories,
+                        max_results=max_results * _RERANK_CANDIDATE_MULTIPLIER,
+                        time_range=time_range,
+                        language=language,
+                        region=region_normalized,
+                        include_domains=include_domains,
+                        exclude_domains=exclude_domains,
+                        searxng_url=live_searxng_url,
+                    ),
+                    "search",
+                )
+                if result.startswith("Error"):
+                    return result, None
                 try:
                     data = json.loads(result)
-                    modified = False
-
-                    # Rerank by semantic relevance (same as research/docs)
-                    try:
-                        raw_results = data.get("results", [])
-                        results_list = [
-                            r
-                            for r in raw_results
-                            if any(
-                                isinstance(value, str) and value.strip()
-                                for value in (r.get("content"), r.get("snippet"))
-                            )
-                        ]
-                        if len(results_list) != len(raw_results):
-                            data["results"] = results_list[:max_results]
-                            data["total"] = len(data["results"])
-                            modified = True
-                        if results_list:
-                            # Normalize the usable body for reranking and output.
-                            for r in results_list:
-                                content = r.get("content")
-                                snippet = r.get("snippet")
-                                if not isinstance(content, str) or not content.strip():
-                                    r["content"] = snippet
-                                if not isinstance(snippet, str) or not snippet.strip():
-                                    r["snippet"] = r["content"]
-                            reranked = await _rerank_results(
-                                query, results_list, top_n=max_results
-                            )
-                            if reranked:
-                                data["results"] = reranked
-                                data["total"] = len(data["results"])
-                                modified = True
-                    except Exception as e:
-                        logger.warning(
-                            f"Search reranking step failed for query {query!r}, "
-                            f"returning backend order: {type(e).__name__}: {e}"
-                        )
-
-                    # Optional snippet enrichment
-                    if enrich:
-                        try:
-                            results_list = data.get("results", [])
-                            if results_list:
-                                from wet_mcp.sources.search_strategies import (
-                                    enrich_snippets,
-                                )
-
-                                enriched = await enrich_snippets(
-                                    results_list, query, top_n=5
-                                )
-                                data["results"] = enriched
-                                modified = True
-                        except Exception as e:
-                            # enrich=True is an explicit opt-in the caller pays
-                            # latency for. Dropping it at debug level returns
-                            # plain snippets that look like a successful
-                            # enrichment.
-                            logger.warning(
-                                f"Snippet enrichment (enrich=True) failed for "
-                                f"query {query!r}; returning unenriched "
-                                f"snippets: {type(e).__name__}: {e}"
-                            )
-
-                    # Citation standardization (always on -- cheap pure-python).
-                    try:
-                        results_list = data.get("results", [])
-                        if results_list:
-                            data["results"] = standardize_results(
-                                results_list,
-                                cache_age_seconds=None,
-                                ttl_seconds=ttl,
-                            )
-                            modified = True
-                    except Exception as e:
-                        # Pure-python and always on, so a failure here is our
-                        # own bug, not an upstream outage.
-                        logger.warning(
-                            f"Citation standardization failed for query "
-                            f"{query!r}; results ship without freshness / "
-                            f"citation metadata: {type(e).__name__}: {e}"
-                        )
-
-                    if modified:
-                        result = json.dumps(data, ensure_ascii=False, indent=2)
                 except json.JSONDecodeError:
-                    pass
-            if _web_cache and not result.startswith("Error"):
+                    return result, None
+                # Rerank by semantic relevance (same as research/docs). The
+                # rerank anchor is the query actually sent to the chain for
+                # this round (with expand=True the original behavior reranked
+                # against the pre-expansion query).
+                try:
+                    raw_results = data.get("results", [])
+                    results_list = [
+                        r
+                        for r in raw_results
+                        if any(
+                            isinstance(value, str) and value.strip()
+                            for value in (r.get("content"), r.get("snippet"))
+                        )
+                    ]
+                    if len(results_list) != len(raw_results):
+                        data["results"] = results_list[:max_results]
+                        data["total"] = len(data["results"])
+                    if results_list:
+                        # Normalize the usable body for reranking and output.
+                        for r in results_list:
+                            content = r.get("content")
+                            snippet = r.get("snippet")
+                            if not isinstance(content, str) or not content.strip():
+                                r["content"] = snippet
+                            if not isinstance(snippet, str) or not snippet.strip():
+                                r["snippet"] = r["content"]
+                        reranked = await _rerank_results(
+                            round_query, results_list, top_n=max_results
+                        )
+                        if reranked:
+                            data["results"] = reranked
+                            data["total"] = len(data["results"])
+                except Exception as e:
+                    logger.warning(
+                        f"Search reranking step failed for query {round_query!r}, "
+                        f"returning backend order: {type(e).__name__}: {e}"
+                    )
+                return json.dumps(data, ensure_ascii=False, indent=2), data
+
+            raw, data = await _round(search_query)
+            if data is None:
+                if raw.startswith("Error"):
+                    return _payload(raw)
+                if _web_cache:
+                    await asyncio.to_thread(
+                        _web_cache.set, "search", cache_params, raw, ttl
+                    )
+                return _payload(raw)
+
+            # Quality-tracked rounds. With refine=True a round that fails the
+            # quality gate (all-empty or mean rerank score below the floor)
+            # triggers at most 2 re-queries with LLM-rewritten terms; the
+            # best round by quality wins (ties keep the original query).
+            rounds: list[tuple[float, dict[str, Any]]] = [
+                (round_quality(data.get("results", [])), data)
+            ]
+            if refine:
+                tried: list[str] = [search_query]
+                current = search_query
+                for _ in range(2):  # hard bound: max 2 review rounds
+                    if not refine_needed(rounds[-1][1].get("results", [])):
+                        break
+                    from wet_mcp.sources.search_strategies import rewrite_query
+
+                    results_now = rounds[-1][1].get("results", [])
+                    if results_now:
+                        scored = [
+                            r["score"]
+                            for r in results_now
+                            if isinstance(r.get("score"), (int, float))
+                            and not isinstance(r.get("score"), bool)
+                        ]
+                        reason = (
+                            f"low relevance (mean score {sum(scored) / len(scored):.2f})"
+                            if scored
+                            else "irrelevant results"
+                        )
+                    else:
+                        reason = "no results at all"
+                    rewritten = await rewrite_query(current, avoid=tried, reason=reason)
+                    if not rewritten:
+                        break  # no LLM available or nothing new to try
+                    tried.append(rewritten)
+                    _r_raw, r_data = await _round(rewritten)
+                    if r_data is None:
+                        break  # a failed round never poisons the best-round pick
+                    rounds.append((round_quality(r_data.get("results", [])), r_data))
+                    current = rewritten
+            _, data = max(rounds, key=lambda pair: pair[0])
+
+            # Optional snippet enrichment
+            if enrich:
+                try:
+                    results_list = data.get("results", [])
+                    if results_list:
+                        from wet_mcp.sources.search_strategies import (
+                            enrich_snippets,
+                        )
+
+                        enriched = await enrich_snippets(results_list, query, top_n=5)
+                        data["results"] = enriched
+                except Exception as e:
+                    # enrich=True is an explicit opt-in the caller pays
+                    # latency for. Dropping it at debug level returns
+                    # plain snippets that look like a successful
+                    # enrichment.
+                    logger.warning(
+                        f"Snippet enrichment (enrich=True) failed for "
+                        f"query {query!r}; returning unenriched "
+                        f"snippets: {type(e).__name__}: {e}"
+                    )
+
+            # Citation standardization (always on -- cheap pure-python).
+            try:
+                results_list = data.get("results", [])
+                if results_list:
+                    data["results"] = standardize_results(
+                        results_list,
+                        cache_age_seconds=None,
+                        ttl_seconds=ttl,
+                    )
+            except Exception as e:
+                # Pure-python and always on, so a failure here is our
+                # own bug, not an upstream outage.
+                logger.warning(
+                    f"Citation standardization failed for query "
+                    f"{query!r}; results ship without freshness / "
+                    f"citation metadata: {type(e).__name__}: {e}"
+                )
+
+            result = json.dumps(data, ensure_ascii=False, indent=2)
+            if _web_cache:
                 await asyncio.to_thread(
                     _web_cache.set, "search", cache_params, result, ttl
                 )

--- a/src/wet_mcp/sources/_search_polish.py
+++ b/src/wet_mcp/sources/_search_polish.py
@@ -22,6 +22,7 @@ otherwise; values past half the action's TTL are flagged ``stale``.
 
 from __future__ import annotations
 
+import math
 import re
 from typing import Any
 from urllib.parse import urlparse
@@ -151,3 +152,36 @@ def search_ttl_seconds(time_range: str | None) -> int:
     aggressively because the user is asking for recent content.
     """
     return 300 if time_range else 3600
+
+
+# Refinement (refine=true) quality gate: a round whose mean rerank score
+# falls below this floor counts as low quality and triggers one more
+# LLM-rewritten round (bounded). Chosen to sit above the point where a
+# reranked list is mostly noise; rounds without scores (reranker
+# unavailable) are judged on non-emptiness only.
+_REFINE_MIN_MEAN_SCORE = 0.35
+
+
+def round_quality(results: list[dict[str, Any]]) -> float:
+    """Mean rerank score of a round's results.
+
+    Empty -> 0.0 (worst). Results carrying no finite numeric ``score`` (the
+    reranker was unavailable) -> 1.0: with no quality signal, non-emptiness
+    is success and refinement would only burn tokens. Finite guarantee: a
+    NaN/inf score is ignored rather than poisoning the mean.
+    """
+    if not results:
+        return 0.0
+    scores = [
+        float(s)
+        for s in (r.get("score") for r in results)
+        if isinstance(s, (int, float)) and not isinstance(s, bool) and math.isfinite(s)
+    ]
+    if not scores:
+        return 1.0
+    return sum(scores) / len(scores)
+
+
+def refine_needed(results: list[dict[str, Any]]) -> bool:
+    """Whether a round failed the quality gate (empty or low mean score)."""
+    return round_quality(results) < _REFINE_MIN_MEAN_SCORE

--- a/src/wet_mcp/sources/search_backends.py
+++ b/src/wet_mcp/sources/search_backends.py
@@ -36,6 +36,7 @@ class SearchBackend(Protocol):
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
         categories: str = "general",
+        region: str | None = None,
     ) -> str: ...
 
 
@@ -75,6 +76,203 @@ async def _search_with_rotation(
         return json.dumps({"error": f"{provider} search failed: {type(exc).__name__}"})
 
 
+# Backends with native geo/region support. ``region`` is an ISO 3166-1 alpha-2
+# code (``"US"``, ``"vn"``). A backend outside this set never receives the
+# value silently: the chain skips it with a warning naming it, and when no
+# configured backend supports it the caller gets a structured error naming
+# them. The region is never silently dropped.
+_REGION_SUPPORTED_BACKENDS = frozenset({"searxng", "brave", "tavily"})
+
+
+def _searxng_locale(language: str | None, region: str | None) -> str | None:
+    """Map ``language`` + ``region`` onto SearXNG's single ``language`` locale.
+
+    SearXNG takes one ``language`` parameter in ``<lang>-<REGION>`` form, so
+    ``language="vi", region="vn"`` -> ``"vi-VN"``; a bare region passes
+    through as-is.
+    """
+    if region and language:
+        return f"{language}-{region.upper()}"
+    if region:
+        return region.upper()
+    return language
+
+
+# Tavily's ``country`` parameter is a closed enum of lowercase country names
+# (docs.tavily.com API reference, enum extracted 2026-09-02), so an ISO
+# 3166-1 alpha-2 ``region`` must map through this table. A code Tavily does
+# not carry yields an explicit error naming the backend -- never a silent
+# drop of the geo filter.
+_TAVILY_COUNTRY_BY_ISO: dict[str, str] = {
+    "af": "afghanistan",
+    "al": "albania",
+    "dz": "algeria",
+    "ad": "andorra",
+    "ao": "angola",
+    "ar": "argentina",
+    "am": "armenia",
+    "au": "australia",
+    "at": "austria",
+    "az": "azerbaijan",
+    "bs": "bahamas",
+    "bh": "bahrain",
+    "bd": "bangladesh",
+    "bb": "barbados",
+    "by": "belarus",
+    "be": "belgium",
+    "bz": "belize",
+    "bj": "benin",
+    "bt": "bhutan",
+    "bo": "bolivia",
+    "ba": "bosnia and herzegovina",
+    "bw": "botswana",
+    "br": "brazil",
+    "bn": "brunei",
+    "bg": "bulgaria",
+    "bf": "burkina faso",
+    "bi": "burundi",
+    "kh": "cambodia",
+    "cm": "cameroon",
+    "ca": "canada",
+    "cv": "cape verde",
+    "cf": "central african republic",
+    "td": "chad",
+    "cl": "chile",
+    "cn": "china",
+    "co": "colombia",
+    "km": "comoros",
+    "cg": "congo",
+    "cr": "costa rica",
+    "hr": "croatia",
+    "cu": "cuba",
+    "cy": "cyprus",
+    "cz": "czech republic",
+    "dk": "denmark",
+    "dj": "djibouti",
+    "do": "dominican republic",
+    "ec": "ecuador",
+    "eg": "egypt",
+    "sv": "el salvador",
+    "gq": "equatorial guinea",
+    "er": "eritrea",
+    "ee": "estonia",
+    "et": "ethiopia",
+    "fj": "fiji",
+    "fi": "finland",
+    "fr": "france",
+    "ga": "gabon",
+    "gm": "gambia",
+    "ge": "georgia",
+    "de": "germany",
+    "gh": "ghana",
+    "gr": "greece",
+    "gt": "guatemala",
+    "gn": "guinea",
+    "ht": "haiti",
+    "hn": "honduras",
+    "hu": "hungary",
+    "is": "iceland",
+    "in": "india",
+    "id": "indonesia",
+    "ir": "iran",
+    "iq": "iraq",
+    "ie": "ireland",
+    "il": "israel",
+    "it": "italy",
+    "jm": "jamaica",
+    "jp": "japan",
+    "jo": "jordan",
+    "kz": "kazakhstan",
+    "ke": "kenya",
+    "kw": "kuwait",
+    "kg": "kyrgyzstan",
+    "lv": "latvia",
+    "lb": "lebanon",
+    "ls": "lesotho",
+    "lr": "liberia",
+    "ly": "libya",
+    "li": "liechtenstein",
+    "lt": "lithuania",
+    "lu": "luxembourg",
+    "mg": "madagascar",
+    "mw": "malawi",
+    "my": "malaysia",
+    "mv": "maldives",
+    "ml": "mali",
+    "mt": "malta",
+    "mr": "mauritania",
+    "mu": "mauritius",
+    "mx": "mexico",
+    "md": "moldova",
+    "mc": "monaco",
+    "mn": "mongolia",
+    "me": "montenegro",
+    "ma": "morocco",
+    "mz": "mozambique",
+    "mm": "myanmar",
+    "na": "namibia",
+    "np": "nepal",
+    "nl": "netherlands",
+    "nz": "new zealand",
+    "ni": "nicaragua",
+    "ne": "niger",
+    "ng": "nigeria",
+    "kp": "north korea",
+    "mk": "north macedonia",
+    "no": "norway",
+    "om": "oman",
+    "pk": "pakistan",
+    "pa": "panama",
+    "pg": "papua new guinea",
+    "py": "paraguay",
+    "pe": "peru",
+    "ph": "philippines",
+    "pl": "poland",
+    "pt": "portugal",
+    "qa": "qatar",
+    "ro": "romania",
+    "ru": "russia",
+    "rw": "rwanda",
+    "sa": "saudi arabia",
+    "sn": "senegal",
+    "rs": "serbia",
+    "sg": "singapore",
+    "sk": "slovakia",
+    "si": "slovenia",
+    "so": "somalia",
+    "za": "south africa",
+    "kr": "south korea",
+    "ss": "south sudan",
+    "es": "spain",
+    "lk": "sri lanka",
+    "sd": "sudan",
+    "se": "sweden",
+    "ch": "switzerland",
+    "sy": "syria",
+    "tw": "taiwan",
+    "tj": "tajikistan",
+    "tz": "tanzania",
+    "th": "thailand",
+    "tg": "togo",
+    "tt": "trinidad and tobago",
+    "tn": "tunisia",
+    "tr": "turkey",
+    "tm": "turkmenistan",
+    "ug": "uganda",
+    "ua": "ukraine",
+    "ae": "united arab emirates",
+    "gb": "united kingdom",
+    "us": "united states",
+    "uy": "uruguay",
+    "uz": "uzbekistan",
+    "ve": "venezuela",
+    "vn": "vietnam",
+    "ye": "yemen",
+    "zm": "zambia",
+    "zw": "zimbabwe",
+}
+
+
 class SearxngBackend:
     name = "searxng"
 
@@ -90,6 +288,7 @@ class SearxngBackend:
         include_domains=None,
         exclude_domains=None,
         categories="general",
+        region=None,
     ) -> str:
         from wet_mcp.sources.searxng import search as searxng_search
 
@@ -99,7 +298,7 @@ class SearxngBackend:
             categories=categories,
             max_results=max_results,
             time_range=time_range,
-            language=language,
+            language=_searxng_locale(language, region),
             include_domains=include_domains,
             exclude_domains=exclude_domains,
         )
@@ -113,7 +312,7 @@ class TavilyBackend:
     def __init__(self, keys: list[str]) -> None:
         self.keys = keys
 
-    async def _search_one(self, key, query, max_results) -> str:
+    async def _search_one(self, key, query, max_results, country=None) -> str:
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(
                 self._URL,
@@ -122,6 +321,7 @@ class TavilyBackend:
                     "query": query,
                     "max_results": max_results,
                     "search_depth": "basic",
+                    **({"country": country} if country else {}),
                 },
             )
             if resp.status_code != 200:
@@ -151,10 +351,27 @@ class TavilyBackend:
         include_domains=None,
         exclude_domains=None,
         categories="general",
+        region=None,
     ) -> str:
+        if region:
+            country = _TAVILY_COUNTRY_BY_ISO.get(region.lower())
+            if country is None:
+                # Explicit, structured, backend-named: never silently drop
+                # the requested geo filter.
+                return json.dumps(
+                    {
+                        "error": (
+                            f"tavily does not support region={region!r}: "
+                            "not a code in Tavily's country list"
+                        )
+                    },
+                    ensure_ascii=False,
+                )
+        else:
+            country = None
         return await _search_with_rotation(
             self.keys,
-            lambda key: self._search_one(key, query, max_results),
+            lambda key: self._search_one(key, query, max_results, country),
             "Tavily",
         )
 
@@ -173,7 +390,9 @@ class BraveBackend:
     def __init__(self, keys: list[str]) -> None:
         self.keys = keys
 
-    async def _search_one(self, key, query, max_results, time_range, language) -> str:
+    async def _search_one(
+        self, key, query, max_results, time_range, language, region=None
+    ) -> str:
         params: dict[str, str | int] = {
             "q": query,
             "count": min(max(max_results, 1), 20),
@@ -187,6 +406,9 @@ class BraveBackend:
                 params["freshness"] = freshness
         if language:
             params["search_lang"] = language
+        if region:
+            # Brave expects a 2-char ISO 3166-1 alpha-2 country code.
+            params["country"] = region.upper()
         headers = {"X-Subscription-Token": key, "Accept": "application/json"}
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.get(self._URL, params=params, headers=headers)
@@ -217,10 +439,13 @@ class BraveBackend:
         include_domains=None,
         exclude_domains=None,
         categories="general",
+        region=None,
     ) -> str:
         return await _search_with_rotation(
             self.keys,
-            lambda key: self._search_one(key, query, max_results, time_range, language),
+            lambda key: self._search_one(
+                key, query, max_results, time_range, language, region
+            ),
             "Brave",
         )
 
@@ -282,7 +507,16 @@ class ExaBackend:
         include_domains=None,
         exclude_domains=None,
         categories="general",
+        region=None,
     ) -> str:
+        if region:
+            # Exa's /search API has no geo parameter. Structured error naming
+            # the backend so the chain advances (or the caller sees) instead
+            # of silently searching without the requested region.
+            return json.dumps(
+                {"error": f"exa does not support region filtering (region={region!r})"},
+                ensure_ascii=False,
+            )
         return await _search_with_rotation(
             self.keys,
             lambda key: self._search_one(
@@ -435,15 +669,51 @@ async def run_search_chain(
     exclude_domains=None,
     categories="general",
     searxng_url: str | None = None,
+    region: str | None = None,
 ) -> str:
     """Run the configured search chain and report the selected backend.
 
     Providers are tried in order. Errors and empty results advance the chain.
     The returned envelope records requested, attempted, selected, and fallback
     state without exposing provider credentials or endpoints.
+
+    ``region`` (ISO 3166-1 alpha-2) is forwarded only to backends with native
+    geo support (searxng / brave / tavily). A backend without support is
+    skipped with a warning naming it; when no configured backend supports it,
+    a structured error naming them is returned -- the geo filter is never
+    silently dropped.
     """
     requested = chain_backend_names()
     backends = search_backends_from_env(searxng_url)
+    if region and backends:
+        unsupported = [
+            b.name for b in backends if b.name not in _REGION_SUPPORTED_BACKENDS
+        ]
+        if unsupported:
+            logger.warning(
+                f"region={region!r} not supported by search backend(s): "
+                f"{', '.join(unsupported)}; skipping them"
+            )
+            backends = [b for b in backends if b.name in _REGION_SUPPORTED_BACKENDS]
+        if not backends:
+            return json.dumps(
+                {
+                    "results": [],
+                    "total": 0,
+                    "query": query,
+                    "error": (
+                        f"region={region!r} is not supported by search "
+                        f"backend(s): {', '.join(unsupported)}"
+                    ),
+                    "search_backend": {
+                        "requested": requested,
+                        "attempted": [],
+                        "selected": None,
+                        "fallback": "unavailable",
+                    },
+                },
+                ensure_ascii=False,
+            )
     if not backends:
         msg = (
             f"Search backends {requested} are missing API keys; configure a key or add searxng"
@@ -483,6 +753,7 @@ async def run_search_chain(
                     include_domains=include_domains,
                     exclude_domains=exclude_domains,
                     categories=categories,
+                    region=region,
                 )
             except Exception:
                 had_provider_failure = True

--- a/src/wet_mcp/sources/search_strategies.py
+++ b/src/wet_mcp/sources/search_strategies.py
@@ -53,6 +53,59 @@ async def expand_query(query: str) -> list[str]:
         return [query]
 
 
+async def rewrite_query(
+    query: str,
+    avoid: list[str] | None = None,
+    reason: str = "",
+) -> str | None:
+    """LLM-rewrite one search query for a refinement round.
+
+    Returns a single rewritten query, or ``None`` when refinement cannot
+    proceed (local mode, LLM unavailable/empty, or a rewrite that merely
+    repeats a query already tried). Token cost is bounded by ``max_tokens``;
+    callers bound the number of rounds.
+    """
+    mode = settings.resolve_provider_mode()
+    if mode == "local":
+        return None
+    avoid = avoid or []
+    try:
+        config = get_llm_config()
+        prompt = (
+            f"Rewrite this web search query to find better results: '{query}'\n"
+            "Return ONLY the rewritten query on one line. "
+            "Fix vagueness, add discriminating keywords, drop noise."
+        )
+        if reason:
+            prompt += f"\nThe problem with the previous results: {reason}"
+        if avoid:
+            prompt += (
+                "\nDo NOT restate any of these already-tried queries: "
+                + "; ".join(avoid[:5])
+            )
+        response = await acompletion(
+            model=config["model"],
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.4,
+            max_tokens=60,
+            **{
+                k: v
+                for k, v in config.items()
+                if k not in ("model", "fallbacks", "temperature")
+            },
+        )
+        rewritten = (
+            (response.choices[0].message.content or "").strip().strip('"').strip("'")
+        )
+        rewritten = rewritten.splitlines()[0].strip() if rewritten else ""
+        if not rewritten or rewritten.lower() == query.lower() or rewritten in avoid:
+            return None
+        return rewritten
+    except Exception as e:
+        logger.debug(f"Query rewrite failed, refinement stops: {e}")
+        return None
+
+
 async def find_similar(
     url: str,
     max_results: int = 10,

--- a/tests/test_search_region_refine.py
+++ b/tests/test_search_region_refine.py
@@ -1,0 +1,339 @@
+"""W2-2: optional ``region`` geo filter + opt-in bounded refinement.
+
+Covers:
+- region plumbing per backend (SearXNG locale mapping, Tavily country enum,
+  Brave ``country`` param) including explicit structured errors naming a
+  backend that cannot honor the region;
+- the chain-level rule: unsupported backends are skipped (named), and a chain
+  with no region-capable backend returns a structured error;
+- refine=True: max 2 review rounds, LLM-rewritten re-queries only when the
+  quality gate fails, best round wins, provenance preserved.
+"""
+
+import json
+import unittest.mock
+
+from structured import payload
+
+from wet_mcp.sources.search_backends import (
+    _TAVILY_COUNTRY_BY_ISO,
+    BraveBackend,
+    ExaBackend,
+    SearxngBackend,
+    TavilyBackend,
+    _searxng_locale,
+    run_search_chain,
+)
+
+# ---------------------------------------------------------------------------
+# Region plumbing per backend
+# ---------------------------------------------------------------------------
+
+
+def test_searxng_locale_mapping():
+    assert _searxng_locale("vi", "vn") == "vi-VN"
+    assert _searxng_locale(None, "us") == "US"
+    assert _searxng_locale("en", None) == "en"
+    assert _searxng_locale(None, None) is None
+
+
+async def test_searxng_region_plumbs_combined_locale():
+    seen = {}
+
+    async def fake_searxng_search(**kwargs):
+        seen.update(kwargs)
+        return json.dumps({"results": [], "total": 0, "query": kwargs["query"]})
+
+    with unittest.mock.patch(
+        "wet_mcp.sources.searxng.search", side_effect=fake_searxng_search
+    ):
+        await SearxngBackend("http://x").search("q", language="vi", region="vn")
+    assert seen["language"] == "vi-VN"
+
+
+async def test_tavily_region_maps_iso_to_country_enum():
+    with unittest.mock.patch("httpx.AsyncClient.post") as post:
+        resp = unittest.mock.AsyncMock()
+        resp.status_code = 200
+        resp.json = unittest.mock.Mock(return_value={"results": []})
+        post.return_value = resp
+        await TavilyBackend(["k"]).search("q", region="US")
+        body = post.call_args.kwargs["json"]
+        assert body["country"] == "united states"
+
+
+async def test_tavily_region_unknown_code_is_structured_error():
+    with unittest.mock.patch("httpx.AsyncClient.post") as post:
+        out = json.loads(await TavilyBackend(["k"]).search("q", region="zz"))
+        assert "tavily" in out["error"]
+        assert "zz" in out["error"]
+        post.assert_not_awaited()
+
+
+async def test_tavily_no_region_omits_country():
+    with unittest.mock.patch("httpx.AsyncClient.post") as post:
+        resp = unittest.mock.AsyncMock()
+        resp.status_code = 200
+        resp.json = unittest.mock.Mock(return_value={"results": []})
+        post.return_value = resp
+        await TavilyBackend(["k"]).search("q")
+        assert "country" not in post.call_args.kwargs["json"]
+
+
+async def test_brave_region_sets_country_param():
+    with unittest.mock.patch("httpx.AsyncClient.get") as get:
+        resp = unittest.mock.AsyncMock()
+        resp.status_code = 200
+        resp.json = unittest.mock.Mock(return_value={"web": {"results": []}})
+        get.return_value = resp
+        await BraveBackend(["k"]).search("q", region="de")
+        assert get.call_args.kwargs["params"]["country"] == "DE"
+
+
+async def test_exa_region_returns_structured_error_naming_backend():
+    with unittest.mock.patch("httpx.AsyncClient.post") as post:
+        out = json.loads(await ExaBackend(["k"]).search("q", region="US"))
+        assert "exa" in out["error"]
+        post.assert_not_awaited()
+
+
+def test_tavily_country_table_is_complete_and_unique():
+    assert len(_TAVILY_COUNTRY_BY_ISO) == 166
+    assert len(set(_TAVILY_COUNTRY_BY_ISO.values())) == 166
+    # spot checks against the provider enum
+    assert _TAVILY_COUNTRY_BY_ISO["vn"] == "vietnam"
+    assert _TAVILY_COUNTRY_BY_ISO["gb"] == "united kingdom"
+    assert _TAVILY_COUNTRY_BY_ISO["kr"] == "south korea"
+
+
+# ---------------------------------------------------------------------------
+# Chain-level region handling (never a silent drop)
+# ---------------------------------------------------------------------------
+
+
+def _mock_backend(name, responder):
+    b = unittest.mock.Mock()
+    b.name = name
+    b.search = unittest.mock.AsyncMock(side_effect=responder)
+    return b
+
+
+async def test_run_search_chain_region_skips_unsupported_backend_named(
+    monkeypatch,
+):
+    monkeypatch.setenv("SEARCH_BACKENDS", "exa,brave")
+
+    async def hit(**_kwargs):
+        return json.dumps(
+            {"results": [{"url": "https://h/1"}], "total": 1, "query": "q"}
+        )
+
+    exa = _mock_backend("exa", hit)
+    brave = _mock_backend("brave", hit)
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[exa, brave],
+    ):
+        out = json.loads(await run_search_chain("q", region="US"))
+
+    assert out["results"][0]["url"] == "https://h/1"
+    exa.search.assert_not_awaited()
+    assert out["search_backend"]["attempted"] == ["brave"]
+
+
+async def test_run_search_chain_region_all_unsupported_is_structured_error(
+    monkeypatch,
+):
+    monkeypatch.setenv("SEARCH_BACKENDS", "exa")
+
+    async def hit(**_kwargs):
+        return json.dumps(
+            {"results": [{"url": "https://h/1"}], "total": 1, "query": "q"}
+        )
+
+    exa = _mock_backend("exa", hit)
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[exa],
+    ):
+        out = json.loads(await run_search_chain("q", region="US"))
+
+    assert out["results"] == []
+    assert "exa" in out["error"]
+    assert "US" in out["error"]
+    exa.search.assert_not_awaited()
+    assert out["search_backend"]["fallback"] == "unavailable"
+
+
+async def test_run_search_chain_region_reaches_capable_backend(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "brave")
+    seen = {}
+
+    async def hit(**kwargs):
+        seen.update(kwargs)
+        return json.dumps(
+            {"results": [{"url": "https://h/1"}], "total": 1, "query": "q"}
+        )
+
+    brave = _mock_backend("brave", hit)
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[brave],
+    ):
+        out = json.loads(await run_search_chain("q", region="vn"))
+
+    assert out["results"][0]["url"] == "https://h/1"
+    assert brave.search.call_args.kwargs["region"] == "vn"
+
+
+# ---------------------------------------------------------------------------
+# refine=True: bounded iterative refinement
+# ---------------------------------------------------------------------------
+
+
+def _chain_mock(responses):
+    """Async fake run_search_chain recording queries, returning canned JSON."""
+    calls = []
+
+    async def fake(**kwargs):
+        calls.append(kwargs["query"])
+        return json.dumps(
+            {
+                "results": responses[min(len(calls), len(responses)) - 1],
+                "total": len(responses[min(len(calls), len(responses)) - 1]),
+                "query": kwargs["query"],
+            },
+            ensure_ascii=False,
+        )
+
+    return fake, calls
+
+
+async def _call_search(**overrides):
+    from wet_mcp.server import search
+
+    return await search(action="search", query="python tutorial", **overrides)
+
+
+def _patch_chain(fake):
+    return unittest.mock.patch("wet_mcp.sources.search_backends.run_search_chain", fake)
+
+
+def _patch_rewrite(side_effect):
+    return unittest.mock.patch(
+        "wet_mcp.sources.search_strategies.rewrite_query",
+        unittest.mock.AsyncMock(side_effect=side_effect),
+    )
+
+
+async def test_refine_requeries_on_empty_with_rewritten_terms(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    empty: list = []
+    hit = [{"url": "https://e/1", "title": "R1", "snippet": "s", "score": 0.9}]
+    fake, calls = _chain_mock([empty, hit])
+    with _patch_chain(fake), _patch_rewrite(["better python tutorial"]):
+        result = await _call_search(refine=True)
+    out = payload(result)
+    assert len(calls) == 2
+    assert calls[1] == "better python tutorial"
+    assert out["results"][0]["url"] == "https://e/1"
+    assert "error" not in out
+
+
+async def test_refine_bound_max_two_review_rounds(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    fake, calls = _chain_mock([[], [], []])
+    with _patch_chain(fake), _patch_rewrite(["r1", "r2", "r3"]):
+        result = await _call_search(refine=True)
+    out = payload(result)
+    # initial round + at most 2 review rounds, however eager the rewriter is
+    assert len(calls) == 3
+    assert out["results"] == []
+    assert "error" not in out  # valid-empty, not an error
+
+
+async def test_refine_stops_when_rewrite_unavailable(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    fake, calls = _chain_mock([[]])
+    with _patch_chain(fake), _patch_rewrite([None]):
+        result = await _call_search(refine=True)
+    out = payload(result)
+    assert len(calls) == 1
+    assert out["results"] == []
+    assert "error" not in out
+
+
+async def test_refine_skipped_when_quality_gate_passes(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    good = [{"url": "https://e/1", "title": "R1", "snippet": "s", "score": 0.9}]
+    fake, calls = _chain_mock([good])
+    rewrite = unittest.mock.AsyncMock()
+    with _patch_chain(fake), _patch_rewrite(rewrite):
+        result = await _call_search(refine=True)
+    out = payload(result)
+    assert len(calls) == 1
+    rewrite.assert_not_awaited()
+    assert out["results"][0]["score"] == 0.9
+
+
+async def test_refine_returns_best_round_with_provenance(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    weak = [{"url": "https://a/1", "title": "A", "snippet": "s", "score": 0.1}]
+    better = [{"url": "https://b/1", "title": "B", "snippet": "s", "score": 0.9}]
+    fake, calls = _chain_mock([weak, better])
+    with _patch_chain(fake), _patch_rewrite(["refined q"]):
+        result = await _call_search(refine=True)
+    out = payload(result)
+    assert len(calls) == 2
+    top = out["results"][0]
+    assert top["url"] == "https://b/1"
+    assert top["score"] == 0.9
+    # provenance fields survive the round switch (standardize ran on winner)
+    assert top["source_domain"] == "b"
+    assert top["freshness_signal"] in ("fresh", "stale")
+
+
+async def test_no_refine_keeps_single_round(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    fake, calls = _chain_mock([[]])
+    rewrite = unittest.mock.AsyncMock()
+    with _patch_chain(fake), _patch_rewrite(rewrite):
+        result = await _call_search()
+    out = payload(result)
+    assert len(calls) == 1
+    rewrite.assert_not_awaited()
+    assert out["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# Param validation
+# ---------------------------------------------------------------------------
+
+
+async def test_region_param_error_is_structured(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    result = await _call_search(region="usa")
+    out = payload(result)
+    assert "error" in out
+    assert "region" in out["error"]
+
+
+async def test_region_normalized_uppercase_in_plumbing(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "brave")
+    seen = {}
+
+    async def hit(**kwargs):
+        seen.update(kwargs)
+        return json.dumps(
+            {
+                "results": [{"url": "https://h/1", "title": "H", "snippet": "s"}],
+                "total": 1,
+                "query": "q",
+            }
+        )
+
+    with _patch_chain(hit):
+        result = await _call_search(region="vn")
+    out = payload(result)
+    assert seen["region"] == "VN"
+    assert out["results"][0]["url"] == "https://h/1"


### PR DESCRIPTION
## Spec reference
MCP Phase 2 wave-2, item W2-2 (search quality remainder): optional `region` param on the existing search action with per-backend plumbing + explicit unsupported handling, and opt-in bounded iterative refinement (`refine=true`). Base: origin/main `51db4b4b` (#1736 included). Non-STABLE source work.

## Change
- `region` (2-letter ISO 3166-1 alpha-2) on the `search` action:
  - SearXNG: `language`+`region` combined onto SearXNG's single locale param (`vi`+`VN` -> `vi-VN`); web-core passes it through verbatim.
  - Brave: native `country` param (2-char ISO alpha-2, uppercased).
  - Tavily: native `country` param mapped through its closed enum of lowercase country names (all 166 names extracted verbatim from docs.tavily.com API reference, 2026-09-02); an ISO code outside the enum yields a structured error naming `tavily`.
  - Exa: `/search` has no geo parameter -> structured error naming `exa`.
  - Chain rule: unsupported backends are skipped with a warning naming them; a chain with no region-capable backend returns a structured error naming them (with the `search_backend` provenance block, `fallback: "unavailable"`). The geo filter is never silently dropped; #1736 fallback semantics unchanged.
- `refine=true` (default off): when the initial round is all-empty or its mean rerank score is below 0.35, re-query up to 2 times with LLM-rewritten terms (`rewrite_query` in search_strategies, bounded `max_tokens`, avoids already-tried queries). Best round by quality wins; ties keep the original query. No LLM available -> stop after the initial round. All rounds exhausted with nothing -> valid-empty envelope (error-vs-empty preserved). Each round runs the full chain + rerank; provenance (`source_domain`, `freshness_signal`) is standardized on the winning round only.
- Rerank anchor per round is now the query actually sent to the chain (with `expand=True` the old code reranked against the pre-expansion query).
- Invalid `region` (not 2 letters) -> structured param error at the tool boundary.

## Verification
Focused suites (all green):
- `uv run pytest tests/test_search_region_refine.py tests/test_search_backends.py tests/test_search_polish.py tests/test_search_strategies.py -q` => 94 passed
- `uv run pytest tests/test_extract_agent.py tests/test_search_backends_multikey.py tests/test_tool_names.py -q` => 24 passed

Behavioral smoke (mocked chain, live tool path): `region="vn"` normalized to `VN` and observed in the chain call kwargs; standardized result carries `source_domain` + `freshness_signal`; `region="usa"` returns `Invalid region='usa' for search action: expected a 2-letter ISO 3166-1 code (e.g. 'US', 'vn').`

## Non-goals
- No new MCP tools/actions; no provider x auth-tier changes; no env-var renames (`region`/`refine` are per-call params).
- No new research/docs/x behavior — `region`/`refine` apply to the `search` action only.
- Parallel fan-out, SWR cache, budget/EMA (W2-3/W2-4) are separate PRs.

## Rollback
Single squash commit; revert squashes cleanly to `51db4b4b`.