### PR TITLE
feat: stale-while-revalidate cache, per-provider latency EMA, and query budget

### DIFF
--- a/src/wet_mcp/cache.py
+++ b/src/wet_mcp/cache.py
@@ -138,6 +138,32 @@ class WebCache:
         logger.debug(f"Cache MISS: {action} ({key[:12]}...)")
         return None
 
+    def get_stale_with_age(self, action: str, params: dict) -> tuple[str, int] | None:
+        """Serve a TTL-expired entry for stale-while-revalidate reads.
+
+        Returns ``(content, age)`` even when ``expires_at`` has passed, as
+        long as the entry is still within the stale window (one extra TTL
+        past expiry, so total staleness never exceeds 2x the entry's own
+        TTL); ``None`` on miss or once the stale window is exhausted. The
+        caller decides freshness: the existing per-result freshness signal
+        already flags ``"stale"`` once ``age > ttl / 2``.
+        """
+        key = _cache_key(action, params)
+        now = time.time()
+
+        row = self._conn.execute(
+            """SELECT content, created_at, expires_at FROM web_cache
+               WHERE key = ? AND expires_at + (expires_at - created_at) > ?""",
+            (key, now),
+        ).fetchone()
+        if row is None:
+            logger.debug(f"Cache STALE-MISS: {action} ({key[:12]}...)")
+            return None
+
+        age = max(0, int(now - row["created_at"]))
+        logger.debug(f"Cache STALE-HIT: {action} ({key[:12]}...) age={age}s")
+        return row["content"], age
+
     def set(
         self, action: str, params: dict, content: str, ttl_override: int | None = None
     ) -> None:

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -202,6 +202,11 @@ class Settings(BaseSettings):
 
     # Cache (web operations)
     wet_cache: bool = True  # Enable/disable web cache
+    # Per-provider query budget for the web-search chain (env
+    # WET_SEARCH_BUDGET). Counts attempts per provider per process; when a
+    # provider reaches the cap the chain advances past it with a structured
+    # error naming it. 0 (default) = unlimited.
+    wet_search_budget: int = 0
     cache_dir: str = ""  # Cache database directory, default: ~/.wet-mcp
 
     # Docs storage

--- a/src/wet_mcp/search_metrics.py
+++ b/src/wet_mcp/search_metrics.py
@@ -1,0 +1,47 @@
+"""In-memory per-provider search metrics: latency EMA + query counters.
+
+Process-local by design -- no persistence, no new tool. Exposed read-only
+through the existing ``config`` tool ``status`` payload. The EMA (alpha 0.3)
+smooths single-call spikes while staying responsive to provider regressions;
+query counters back the optional per-provider budget (``WET_SEARCH_BUDGET``).
+"""
+
+from __future__ import annotations
+
+# EMA weight of the newest sample.
+_EMA_ALPHA = 0.3
+
+_latency_ema: dict[str, float] = {}
+_query_counts: dict[str, int] = {}
+
+
+def record_query(provider: str) -> None:
+    """Count one query attempt against ``provider`` (budget accounting)."""
+    _query_counts[provider] = _query_counts.get(provider, 0) + 1
+
+
+def query_count(provider: str) -> int:
+    """Queries attempted so far against ``provider`` this process."""
+    return _query_counts.get(provider, 0)
+
+
+def record_latency(provider: str, seconds: float) -> None:
+    """Fold one latency sample into the provider's exponential moving average."""
+    prev = _latency_ema.get(provider)
+    if prev is None:
+        _latency_ema[provider] = seconds
+    else:
+        _latency_ema[provider] = _EMA_ALPHA * seconds + (1 - _EMA_ALPHA) * prev
+
+
+def latency_ema(provider: str) -> float | None:
+    """Current latency EMA for ``provider``, or ``None`` before any call."""
+    return _latency_ema.get(provider)
+
+
+def snapshot() -> dict:
+    """Status-payload view: ``latency_ema_seconds`` + ``query_counts``."""
+    return {
+        "latency_ema_seconds": {k: round(v, 4) for k, v in _latency_ema.items()},
+        "query_counts": dict(_query_counts),
+    }

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -27,6 +27,7 @@ from loguru import logger
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from wet_mcp import search_metrics
 from wet_mcp.cache import WebCache
 from wet_mcp.config import settings
 from wet_mcp.db import (
@@ -1235,7 +1236,6 @@ async def search(  # noqa: PLR0913
                 )
                 if cache_hit:
                     cached_content, cache_age = cache_hit
-                    # Re-stamp freshness signal based on current age.
                     try:
                         cached_data = json.loads(cached_content)
                         if isinstance(cached_data, dict) and cached_data.get("results"):
@@ -1244,6 +1244,30 @@ async def search(  # noqa: PLR0913
                                 cache_age_seconds=cache_age,
                                 ttl_seconds=ttl,
                             )
+                            return cached_data
+                    except json.JSONDecodeError:
+                        pass
+                    return _payload(cached_content)
+
+                # Stale-While-Revalidate: serve stale if within 2x TTL window
+                try:
+                    stale_hit = await asyncio.to_thread(
+                        _web_cache.get_stale_with_age, "search", cache_params
+                    )
+                except Exception:
+                    stale_hit = None
+
+                if stale_hit and isinstance(stale_hit, tuple) and len(stale_hit) == 2:
+                    cached_content, cache_age = stale_hit
+                    try:
+                        cached_data = json.loads(cached_content)
+                        if isinstance(cached_data, dict) and cached_data.get("results"):
+                            cached_data["results"] = standardize_results(
+                                cached_data["results"],
+                                cache_age_seconds=cache_age,
+                                ttl_seconds=ttl,
+                            )
+                            cached_data["stale"] = True
                             return cached_data
                     except json.JSONDecodeError:
                         pass
@@ -2278,6 +2302,7 @@ async def _handle_config_status() -> dict[str, Any]:
         # surface whether the key is set and which model (cheap vs expensive)
         # will be charged before the operator spends anything.
         "x_search": x_search_status(),
+        "search_metrics": search_metrics.snapshot(),
     }
     return status
 
@@ -2292,6 +2317,7 @@ def _handle_config_set(key: str | None, value: str | None) -> dict[str, Any]:
         "sync_enabled",
         "sync_folder",
         "sync_interval",
+        "wet_search_budget",
     }
     if key not in valid_keys:
         import difflib
@@ -2310,7 +2336,7 @@ def _handle_config_set(key: str | None, value: str | None) -> dict[str, Any]:
         settings.log_level = value.upper()
         logger.remove()
         logger.add(sys.stderr, level=settings.log_level)
-    elif key in ("tool_timeout", "sync_interval"):
+    elif key in ("tool_timeout", "sync_interval", "wet_search_budget"):
         setattr(settings, key, int(value))
     elif key in ("wet_cache", "sync_enabled"):
         setattr(settings, key, value.lower() in ("true", "1", "yes"))

--- a/src/wet_mcp/sources/search_backends.py
+++ b/src/wet_mcp/sources/search_backends.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from collections.abc import Awaitable, Callable
 from typing import Protocol
 
@@ -21,6 +22,7 @@ from loguru import logger
 from mcp_core.chains import run_with_fallback
 from mcp_core.llm.key_rotation import rotate_keys, split_keys
 
+from wet_mcp import search_metrics
 from wet_mcp.config import settings
 
 
@@ -714,6 +716,32 @@ async def run_search_chain(
                 },
                 ensure_ascii=False,
             )
+
+    budget = getattr(settings, "wet_search_budget", 0) or 0
+    if budget > 0 and backends:
+        exhausted = [
+            b.name for b in backends if search_metrics.query_count(b.name) >= budget
+        ]
+        if len(exhausted) == len(backends):
+            return json.dumps(
+                {
+                    "results": [],
+                    "total": 0,
+                    "query": query,
+                    "error": (
+                        "search query budget exhausted for provider(s): "
+                        + ", ".join(exhausted)
+                        + f" (WET_SEARCH_BUDGET={budget})"
+                    ),
+                    "search_backend": {
+                        "requested": requested,
+                        "attempted": [],
+                        "selected": None,
+                        "fallback": "unavailable",
+                    },
+                },
+                ensure_ascii=False,
+            )
     if not backends:
         msg = (
             f"Search backends {requested} are missing API keys; configure a key or add searxng"
@@ -743,7 +771,26 @@ async def run_search_chain(
     def traced_thunk(backend: SearchBackend) -> Callable[[], Awaitable[str]]:
         async def invoke() -> str:
             nonlocal had_provider_failure, selected
+            if budget > 0 and search_metrics.query_count(backend.name) >= budget:
+                # Per-provider cap reached: a structured error naming the
+                # provider, which advances the chain (fallback semantics
+                # unchanged) instead of a silent drop.
+                logger.warning(
+                    f"Search backend {backend.name!r} at query budget "
+                    f"({budget}); advancing chain"
+                )
+                return json.dumps(
+                    {
+                        "error": (
+                            f"search query budget exhausted for provider "
+                            f"'{backend.name}' (WET_SEARCH_BUDGET={budget})"
+                        )
+                    },
+                    ensure_ascii=False,
+                )
             attempted.append(backend.name)
+            search_metrics.record_query(backend.name)
+            started = time.perf_counter()
             try:
                 payload = await backend.search(
                     query=query,
@@ -758,6 +805,10 @@ async def run_search_chain(
             except Exception:
                 had_provider_failure = True
                 raise
+            finally:
+                search_metrics.record_latency(
+                    backend.name, time.perf_counter() - started
+                )
             if _search_result_has_failure(payload):
                 had_provider_failure = True
             elif not _search_result_is_empty(payload):

--- a/tests/test_search_swr_budget_ema.py
+++ b/tests/test_search_swr_budget_ema.py
@@ -1,0 +1,146 @@
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from wet_mcp import search_metrics
+from wet_mcp.cache import WebCache
+from wet_mcp.sources.search_backends import run_search_chain
+
+
+def test_cache_get_stale_with_age(tmp_path):
+    cache = WebCache(tmp_path / "cache.db")
+    params = {"query": "python asyncio"}
+    # Store with TTL override = 10s
+    cache.set(
+        "search",
+        params,
+        json.dumps({"results": [{"title": "Asyncio"}]}),
+        ttl_override=10,
+    )
+
+    # 1. Immediate hit: get_with_age is valid
+    hit = cache.get_with_age("search", params)
+    assert hit is not None
+    content, age = hit
+    assert "Asyncio" in content
+    assert age >= 0
+
+    # 2. Simulate expired entry (expires_at in the past, but within 2x TTL window)
+    import time
+
+    now = time.time()
+    with cache._conn:
+        cache._conn.execute(
+            "UPDATE web_cache SET created_at = ?, expires_at = ? WHERE action = 'search'",
+            (now - 15, now - 5),
+        )
+
+    # Fresh hit should be None
+    assert cache.get_with_age("search", params) is None
+
+    # Stale hit should return the content
+    stale_hit = cache.get_stale_with_age("search", params)
+    assert stale_hit is not None
+    stale_content, stale_age = stale_hit
+    assert "Asyncio" in stale_content
+
+    # 3. Simulate very old entry (past 2x TTL window: expired 25s ago for 10s TTL)
+    now = time.time()
+    with cache._conn:
+        cache._conn.execute(
+            "UPDATE web_cache SET created_at = ?, expires_at = ? WHERE action = 'search'",
+            (now - 35, now - 25),
+        )
+    assert cache.get_stale_with_age("search", params) is None
+
+
+def test_search_metrics_ema_and_counts():
+    search_metrics._latency_ema.clear()
+    search_metrics._query_counts.clear()
+
+    # Record query counts
+    search_metrics.record_query("tavily")
+    search_metrics.record_query("tavily")
+    search_metrics.record_query("brave")
+
+    assert search_metrics.query_count("tavily") == 2
+    assert search_metrics.query_count("brave") == 1
+    assert search_metrics.query_count("searxng") == 0
+
+    # Record latency EMA
+    search_metrics.record_latency("tavily", 1.0)
+    assert search_metrics.latency_ema("tavily") == 1.0
+
+    # EMA calculation: 0.3 * 2.0 + 0.7 * 1.0 = 0.6 + 0.7 = 1.3
+    search_metrics.record_latency("tavily", 2.0)
+    ema = search_metrics.latency_ema("tavily")
+    assert ema is not None and abs(ema - 1.3) < 1e-6
+
+    snap = search_metrics.snapshot()
+    assert snap["query_counts"]["tavily"] == 2
+    assert snap["latency_ema_seconds"]["tavily"] == 1.3
+
+
+@pytest.mark.asyncio
+async def test_search_budget_enforcement():
+    search_metrics._latency_ema.clear()
+    search_metrics._query_counts.clear()
+
+    b1 = Mock()
+    b1.name = "b1"
+    b1.search = AsyncMock(
+        return_value=json.dumps({"results": [{"url": "https://b1/1", "title": "B1"}]})
+    )
+
+    b2 = Mock()
+    b2.name = "b2"
+    b2.search = AsyncMock(
+        return_value=json.dumps({"results": [{"url": "https://b2/1", "title": "B2"}]})
+    )
+
+    with patch("wet_mcp.sources.search_backends.settings.wet_search_budget", 1):
+        with patch(
+            "wet_mcp.sources.search_backends.search_backends_from_env",
+            return_value=[b1, b2],
+        ):
+            # 1st call: b1 should be used
+            res1 = await run_search_chain("test query")
+            data1 = json.loads(res1)
+            assert data1["results"][0]["title"] == "B1"
+            assert search_metrics.query_count("b1") == 1
+
+            # 2nd call: b1 has reached budget cap (1), should advance to b2
+            res2 = await run_search_chain("test query 2")
+            data2 = json.loads(res2)
+            assert data2["results"][0]["title"] == "B2"
+            assert (
+                search_metrics.query_count("b1") == 1
+            )  # not incremented because skipped
+            assert search_metrics.query_count("b2") == 1
+
+            # 3rd call: both b1 and b2 reached budget cap -> fails with structured error naming exhausted providers
+            res3 = await run_search_chain("test query 3")
+            data3 = json.loads(res3)
+            assert "error" in data3
+            assert "budget exhausted" in data3["error"].lower()
+            assert "b1" in data3["error"] and "b2" in data3["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_status_and_set_metrics():
+    from wet_mcp.config import settings
+    from wet_mcp.server import _handle_config_set, _handle_config_status
+
+    search_metrics.record_query("tavily")
+    status = await _handle_config_status()
+    assert "search_metrics" in status
+    assert "query_counts" in status["search_metrics"]
+
+    # Test setting wet_search_budget
+    res = _handle_config_set("wet_search_budget", "50")
+    assert res.get("status") == "updated"
+    assert settings.wet_search_budget == 50
+
+    # Reset
+    settings.wet_search_budget = 0


### PR DESCRIPTION
## Spec
Implements approved Phase 2 wave-2 design §W2-3 (SWR cache, per-provider latency EMA, and query budget).

## Changes
- Add `get_stale_with_age` to `WebCache` to serve TTL-expired results within a bounded 2x TTL window while flagging `stale=True`.
- Implement in-memory `search_metrics` module tracking latency EMA (alpha=0.3) and query counts per provider.
- Expose search metrics snapshot in `_handle_config_status` payload and allow configuring `wet_search_budget` via `_handle_config_set`.
- Enforce `WET_SEARCH_BUDGET` in `run_search_chain` by advancing past capped providers and returning structured errors when all providers are exhausted.

## Verification
- `uv run pytest tests/test_search_swr_budget_ema.py tests/test_search_backends.py tests/test_extract_agent.py -v` -> 45 passed.
- Behavioral smoke: tested budget exhaustion advancement, EMA calculation, stale cache hit with age restamping, and config status payload exposure.

## Non-goals
No persistent metrics store, no new MCP tools, no cross-process coordination.