### PR TITLE
feat: opt-in parallel search fan-out and confidence score exposure

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1136,6 +1136,7 @@ async def search(  # noqa: PLR0913
     video: bool = False,
     region: str | None = None,
     refine: bool = False,
+    parallel: bool = False,
 ) -> dict[str, Any]:
     """Find information across web, academic sources, X/Twitter, or library docs. Returns search result listings (titles, URLs, snippets) -- NOT full page content. To read full content from a URL, use the `extract` tool instead.
 
@@ -1229,6 +1230,7 @@ async def search(  # noqa: PLR0913
                 "region": region_normalized,
                 "include_domains": include_domains,
                 "exclude_domains": exclude_domains,
+                "parallel": parallel,
             }
             if _web_cache:
                 cache_hit = await asyncio.to_thread(
@@ -1317,6 +1319,7 @@ async def search(  # noqa: PLR0913
                         include_domains=include_domains,
                         exclude_domains=exclude_domains,
                         searxng_url=live_searxng_url,
+                        parallel=parallel,
                     ),
                     "search",
                 )
@@ -1498,6 +1501,7 @@ async def search(  # noqa: PLR0913
                 "language": language,
                 "include_domains": include_domains,
                 "exclude_domains": exclude_domains,
+                "parallel": parallel,
             }
             if _web_cache:
                 cached = await asyncio.to_thread(

--- a/src/wet_mcp/sources/_search_polish.py
+++ b/src/wet_mcp/sources/_search_polish.py
@@ -125,6 +125,24 @@ def standardize_citation(
     if published_at:
         out["published_at"] = published_at
 
+    # Attach finite confidence if available in raw result (e.g. rerank/similarity score)
+    score_keys = (
+        "score",
+        "confidence",
+        "relevance",
+        "similarity",
+        "similarity_score",
+        "rerank_score",
+    )
+    for k in score_keys:
+        val = raw.get(k)
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            import math
+
+            if not (math.isnan(val) or math.isinf(val)):
+                out["confidence"] = round(float(val), 4)
+                break
+
     return out
 
 

--- a/src/wet_mcp/sources/search_backends.py
+++ b/src/wet_mcp/sources/search_backends.py
@@ -11,6 +11,7 @@ legitimate and never triggers rotation — only the PROVIDER chain advances on e
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import time
@@ -672,6 +673,7 @@ async def run_search_chain(
     categories="general",
     searxng_url: str | None = None,
     region: str | None = None,
+    parallel: bool = False,
 ) -> str:
     """Run the configured search chain and report the selected backend.
 
@@ -767,6 +769,71 @@ async def run_search_chain(
     attempted: list[str] = []
     selected: str | None = None
     had_provider_failure = False
+
+    if parallel and len(backends) > 1:
+        attempted = [b.name for b in backends]
+        tasks = [
+            backend.search(
+                query=query,
+                max_results=max_results,
+                time_range=time_range,
+                language=language,
+                include_domains=include_domains,
+                exclude_domains=exclude_domains,
+                categories=categories,
+            )
+            for backend in backends
+        ]
+        outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+        merged_results: list[dict] = []
+        seen_urls: set[str] = set()
+        successful_backends: list[str] = []
+        had_failure = False
+
+        for backend, outcome in zip(backends, outcomes, strict=False):
+            if isinstance(outcome, BaseException):
+                logger.warning(
+                    f"Search backend '{backend.name}' raised: {type(outcome).__name__}"
+                )
+                had_failure = True
+                continue
+            try:
+                parsed = json.loads(outcome)
+                if (
+                    isinstance(parsed, dict)
+                    and isinstance(parsed.get("results"), list)
+                    and parsed["results"]
+                ):
+                    successful_backends.append(backend.name)
+                    for item in parsed["results"]:
+                        if isinstance(item, dict):
+                            url = item.get("url")
+                            if url and url not in seen_urls:
+                                seen_urls.add(url)
+                                item_copy = dict(item)
+                                if "source" not in item_copy:
+                                    item_copy["source"] = backend.name
+                                merged_results.append(item_copy)
+                elif isinstance(parsed, dict) and parsed.get("error"):
+                    had_failure = True
+            except Exception:
+                had_failure = True
+
+        data: dict[str, object] = {
+            "results": merged_results[:max_results],
+            "total": len(merged_results),
+            "query": query,
+        }
+        if not merged_results and had_failure:
+            data["error"] = "Search backend chain exhausted after provider failure"
+
+        data["search_backend"] = {
+            "requested": requested,
+            "attempted": attempted,
+            "selected": "+".join(successful_backends) if successful_backends else None,
+            "fallback": "parallel_fanout" if successful_backends else "exhausted",
+        }
+        return json.dumps(data, ensure_ascii=False)
 
     def traced_thunk(backend: SearchBackend) -> Callable[[], Awaitable[str]]:
         async def invoke() -> str:

--- a/tests/test_search_parallel_confidence.py
+++ b/tests/test_search_parallel_confidence.py
@@ -1,0 +1,180 @@
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from wet_mcp.sources._search_polish import standardize_citation
+from wet_mcp.sources.search_backends import run_search_chain
+
+
+def test_standardize_citation_confidence_exposure():
+    # 1. Raw result with score -> exposed as confidence
+    raw1 = {
+        "url": "https://example.com/1",
+        "title": "T1",
+        "snippet": "S1",
+        "score": 0.85672,
+    }
+    std1 = standardize_citation(raw1)
+    assert std1.get("confidence") == 0.8567
+
+    # 2. Raw result with rerank_score -> exposed as confidence
+    raw2 = {
+        "url": "https://example.com/2",
+        "title": "T2",
+        "snippet": "S2",
+        "rerank_score": 0.95,
+    }
+    std2 = standardize_citation(raw2)
+    assert std2.get("confidence") == 0.95
+
+    # 3. Raw result without score -> confidence omitted (no fabrication)
+    raw3 = {"url": "https://example.com/3", "title": "T3", "snippet": "S3"}
+    std3 = standardize_citation(raw3)
+    assert "confidence" not in std3
+
+    # 4. Raw result with invalid/NaN score -> confidence omitted
+    raw4 = {
+        "url": "https://example.com/4",
+        "title": "T4",
+        "snippet": "S4",
+        "score": float("nan"),
+    }
+    std4 = standardize_citation(raw4)
+    assert "confidence" not in std4
+
+
+@pytest.mark.asyncio
+async def test_run_search_chain_parallel_fanout():
+    b1 = Mock()
+    b1.name = "tavily"
+    b1.search = AsyncMock(
+        return_value=json.dumps(
+            {
+                "results": [
+                    {"url": "https://a.com/page1", "title": "A1", "score": 0.9},
+                    {
+                        "url": "https://shared.com/item",
+                        "title": "Shared from Tavily",
+                        "score": 0.8,
+                    },
+                ]
+            }
+        )
+    )
+
+    b2 = Mock()
+    b2.name = "brave"
+    b2.search = AsyncMock(
+        return_value=json.dumps(
+            {
+                "results": [
+                    {
+                        "url": "https://shared.com/item",
+                        "title": "Shared from Brave",
+                        "score": 0.85,
+                    },
+                    {"url": "https://b.com/page2", "title": "B2", "score": 0.75},
+                ]
+            }
+        )
+    )
+
+    with patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[b1, b2],
+    ):
+        with patch(
+            "wet_mcp.sources.search_backends.chain_backend_names",
+            return_value=["tavily", "brave"],
+        ):
+            out_raw = await run_search_chain(
+                "test query", max_results=10, parallel=True
+            )
+            out = json.loads(out_raw)
+
+            # Check deduplication & merged results
+            urls = [r["url"] for r in out["results"]]
+            assert len(urls) == 3
+            assert urls == [
+                "https://a.com/page1",
+                "https://shared.com/item",
+                "https://b.com/page2",
+            ]
+
+            # Search backend metadata
+            assert out["search_backend"]["fallback"] == "parallel_fanout"
+            assert "tavily+brave" in out["search_backend"]["selected"]
+            assert out["search_backend"]["attempted"] == ["tavily", "brave"]
+
+
+@pytest.mark.asyncio
+async def test_run_search_chain_parallel_with_one_failure():
+    b1 = Mock()
+    b1.name = "tavily"
+    b1.search = AsyncMock(side_effect=RuntimeError("tavily timeout"))
+
+    b2 = Mock()
+    b2.name = "brave"
+    b2.search = AsyncMock(
+        return_value=json.dumps(
+            {"results": [{"url": "https://b.com/page", "title": "B1"}]}
+        )
+    )
+
+    with patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[b1, b2],
+    ):
+        with patch(
+            "wet_mcp.sources.search_backends.chain_backend_names",
+            return_value=["tavily", "brave"],
+        ):
+            out_raw = await run_search_chain(
+                "test query", max_results=10, parallel=True
+            )
+            out = json.loads(out_raw)
+
+            assert len(out["results"]) == 1
+            assert out["results"][0]["url"] == "https://b.com/page"
+            assert out["search_backend"]["selected"] == "brave"
+            assert out["search_backend"]["fallback"] == "parallel_fanout"
+
+
+@pytest.mark.asyncio
+async def test_run_search_chain_parallel_false_uses_sequential():
+    b1 = Mock()
+    b1.name = "tavily"
+    b1.search = AsyncMock(
+        return_value=json.dumps(
+            {"results": [{"url": "https://a.com/page1", "title": "A1"}]}
+        )
+    )
+
+    b2 = Mock()
+    b2.name = "brave"
+    b2.search = AsyncMock(
+        return_value=json.dumps(
+            {"results": [{"url": "https://b.com/page2", "title": "B2"}]}
+        )
+    )
+
+    with patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[b1, b2],
+    ):
+        with patch(
+            "wet_mcp.sources.search_backends.chain_backend_names",
+            return_value=["tavily", "brave"],
+        ):
+            out_raw = await run_search_chain(
+                "test query", max_results=10, parallel=False
+            )
+            out = json.loads(out_raw)
+
+            # When parallel=False and b1 succeeds, b2 is not called
+            assert len(out["results"]) == 1
+            assert out["results"][0]["url"] == "https://a.com/page1"
+            assert out["search_backend"]["selected"] == "tavily"
+            assert out["search_backend"]["fallback"] == "none"
+            b2.search.assert_not_called()


### PR DESCRIPTION
## Spec
Implements approved Phase 2 wave-2 design §W2-4 (opt-in parallel search fan-out and confidence score exposure).

## Changes
- Add opt-in `parallel=true` (default false) to `search` tool and `run_search_chain` to run configured backends concurrently via `asyncio.gather` and merge deduplicated results.
- Expose finite `confidence` score in `standardize_citation` when upstream results carry numeric score/similarity/rerank metrics (omitted when absent, no fabrication).
- Preserve sequential fallback chain semantics when `parallel=false` per #1736.

## Verification
- `uv run pytest tests/test_search_parallel_confidence.py tests/test_search_backends.py tests/test_extract_agent.py -v` -> 45 passed.
- Tested: parallel merge with deduplication, single provider failure tolerance in parallel mode, fallback chain preservation when parallel=false, confidence exposure vs omission.

## Non-goals
No cross-provider cache sharing, no new tools, no provider-tier multiplication.