### PR TITLE
fix: resolve ty type-check and regenerate uv.lock

### DIFF
--- a/src/wet_mcp/relay_setup.py
+++ b/src/wet_mcp/relay_setup.py
@@ -105,7 +105,7 @@ async def ensure_config(
 
         from .relay_schema import RELAY_SCHEMA
 
-        session = await create_session(relay_url, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
+        session = await create_session(relay_url, SERVER_NAME, RELAY_SCHEMA)
 
         timeout_msg = f", {int(timeout)}s timeout" if timeout else ""
         print(
@@ -116,7 +116,7 @@ async def ensure_config(
             flush=True,
         )
 
-        config = await poll_for_result(relay_url, session, timeout_s=timeout)  # ty: ignore[invalid-argument-type]
+        config = await poll_for_result(relay_url, session, timeout_s=timeout)
 
         # Save to per-plugin store for future use (~/.wet-mcp/config.json)
         PerPluginStore(PLUGIN_NAME, backend=backend_from_env()).save(config)

--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -42,7 +42,7 @@ def _patched_install_searxng() -> bool:
     return result
 
 
-_wc_runner._install_searxng = _patched_install_searxng  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+_wc_runner._install_searxng = _patched_install_searxng  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +72,7 @@ def _find_available_port(start_port: int, max_tries: int = 100) -> int:
     raise RuntimeError(msg)
 
 
-_wc_runner._find_available_port = _find_available_port  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+_wc_runner._find_available_port = _find_available_port  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Re-export internal functions from web-core for backward compatibility.

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -3543,7 +3543,7 @@ async def run_http_server(port: int = 0) -> None:
     auth_scope = _per_request_sub_scope if public_url else None
 
     await _run_http(
-        mcp,  # ty: ignore[invalid-argument-type]
+        mcp,
         server_name="wet-mcp",
         relay_schema=RELAY_SCHEMA,
         host=host,

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -513,8 +513,8 @@ async def crawl(
 
             async with sem:
                 try:
-                    result = await crawler.arun(  # ty: ignore[missing-argument]
-                        url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
+                    result = await crawler.arun(
+                        url,  # type: ignore[invalid-argument-type]
                         config=_crawler_run_config(),
                     )
 
@@ -603,8 +603,8 @@ async def sitemap(
 
             async with sem:
                 try:
-                    result = await crawler.arun(  # ty: ignore[missing-argument]
-                        url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
+                    result = await crawler.arun(
+                        url,  # type: ignore[invalid-argument-type]
                         config=_crawler_run_config(),
                     )
 
@@ -654,8 +654,8 @@ async def list_media(
     sem = _get_semaphore()
 
     async with sem:
-        result = await crawler.arun(  # ty: ignore[missing-argument]
-            url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
+        result = await crawler.arun(
+            url,  # type: ignore[invalid-argument-type]
             config=_crawler_run_config(),
         )
 

--- a/tests/test_crawler_comprehensive.py
+++ b/tests/test_crawler_comprehensive.py
@@ -616,7 +616,7 @@ async def test_shutdown_crawler_exception_handled():
     mock_crawler.__aexit__.side_effect = Exception("Shutdown error")
 
     with patch("wet_mcp.sources.crawler.AsyncWebCrawler", return_value=mock_crawler):
-        crawler._crawler_instance = mock_crawler  # type: ignore
+        crawler._crawler_instance = mock_crawler
         await crawler.shutdown_crawler()
         assert crawler._crawler_instance is None
 
@@ -659,7 +659,7 @@ async def test_get_crawler_recycle_exception():
     mock_crawler.__aexit__.side_effect = Exception("aexit failed")
     with patch("wet_mcp.sources.crawler.AsyncWebCrawler", return_value=mock_crawler):
         # We need to manually set it so recycle logic triggers
-        crawler._crawler_instance = mock_crawler  # type: ignore
+        crawler._crawler_instance = mock_crawler
         crawler._crawler_stealth = True
         await crawler._get_crawler(stealth=False)
         mock_crawler.__aexit__.assert_called()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -398,7 +398,7 @@ async def test_relay_all_tools(request, tmp_path):
     capture = StderrCapture()
 
     try:
-        async with stdio_client(params, errlog=capture) as (read_stream, write_stream):  # ty: ignore[invalid-argument-type]
+        async with stdio_client(params, errlog=capture) as (read_stream, write_stream):
             async with ClientSession(read_stream, write_stream) as s:
                 await s.initialize()
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -121,7 +121,7 @@ def test_load_non_dict_payload(token_dir):
     # Encrypt a non-dict payload through the store, then read via load_token.
     store = PerPluginStore("wet", None, backend=mem, sub_key="tokens/drive")
     non_dict_payload: object = [1, 2, 3]
-    store.save(non_dict_payload)  # type: ignore
+    store.save(non_dict_payload)
     assert load_token("drive", backend=mem) is None
 
 
@@ -210,7 +210,7 @@ def test_load_token_for_sub_non_dict(token_dir):
     mem = InMemoryBackend()
     store = PerPluginStore("wet", "user1", backend=mem, sub_key="tokens/drive")
     non_dict_payload: object = [1, 2, 3]
-    store.save(non_dict_payload)  # type: ignore
+    store.save(non_dict_payload)
     assert load_token_for_sub("user1", "drive", backend=mem) is None
 
 


### PR DESCRIPTION
## Problem
1. uv.lock had duplicate httpx2 entry blocking CI install
2. ty type-check reported stale suppression comments after lockfile regen

## Fix
- Regenerate uv.lock from scratch
- Remove 16 stale ty/type-ignore comments no longer needed after lockfile cleanup

## Verification
- ty type check: Passed (pre-commit)
- ruff lint/format: Passed
- CI will verify pytest + install