### PR TITLE
fix: gate gdrive on cf-d1; drop jina pins; openrouter free LLM chain

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.release.outputs.tag }}
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - run: uv build
       - name: Publish to PyPI
         run: uv publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Setup Python 3.13
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -256,7 +256,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Setup Python 3.13
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/src/wet_mcp/relay_setup.py
+++ b/src/wet_mcp/relay_setup.py
@@ -141,9 +141,10 @@ async def ensure_config(
 
         # Trigger GDrive OAuth Device Code using default client ID from settings
         from wet_mcp.config import settings as _settings
+        from wet_mcp.credential_state import _sync_redundant_on_cf
 
         gdrive_ok = False
-        if _settings.google_drive_client_id:
+        if _settings.google_drive_client_id and not _sync_redundant_on_cf():
             logger.info("Starting Google Drive OAuth setup...")
             try:
                 from wet_mcp.sync import setup_google_auth

--- a/src/wet_mcp/sync/gdrive.py
+++ b/src/wet_mcp/sync/gdrive.py
@@ -791,6 +791,15 @@ def start_auto_sync(db: DocsDB) -> None:
     if not settings.sync_enabled or settings.sync_interval <= 0:
         return
 
+    # On CF (DOCS_DB_BACKEND=cf-d1) the docs DB lives in D1 + Vectorize and
+    # there is no local file to delta-sync, so the GDrive loop is redundant.
+    # Same deployment-level gate as the device-code trigger in
+    # credential_state._trigger_gdrive_device_code (see F9 tests).
+    from wet_mcp.credential_state import _sync_redundant_on_cf
+
+    if _sync_redundant_on_cf():
+        return
+
     if _sync_task and not _sync_task.done():
         return  # Already running
 

--- a/tests/test_relay_searxng_and_cf_gdrive.py
+++ b/tests/test_relay_searxng_and_cf_gdrive.py
@@ -9,9 +9,11 @@ there (it offered a non-functional setup).
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from wet_mcp.relay_schema import RELAY_SCHEMA
+from wet_mcp.relay_setup import ensure_config
 
 
 def _field(key: str) -> dict | None:
@@ -65,3 +67,82 @@ def test_gdrive_device_code_skipped_on_cf(monkeypatch, tmp_path):
 
     assert mock_post.call_count == 0  # no device/code request on CF
     assert result is None  # no device-code next_step returned to the form
+
+
+def test_gdrive_auto_sync_skipped_on_cf(monkeypatch):
+    """F9 follow-up: the GDrive auto-sync LOOP must also not start on CF."""
+    from wet_mcp.sync import gdrive as gdrive_mod
+
+    monkeypatch.setattr(gdrive_mod.settings, "sync_enabled", True, raising=False)
+    monkeypatch.setattr(gdrive_mod.settings, "sync_interval", 300, raising=False)
+    monkeypatch.setattr(gdrive_mod, "_sync_task", None, raising=False)
+
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    with (
+        patch("asyncio.create_task") as mock_create,
+        patch.object(gdrive_mod, "_auto_sync_loop"),
+    ):
+        gdrive_mod.start_auto_sync(MagicMock())
+    assert mock_create.call_count == 0
+    assert gdrive_mod._sync_task is None
+    # Control: the same settings without the CF marker do start the loop task.
+    monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
+    with (
+        patch("asyncio.create_task") as mock_create,
+        patch.object(gdrive_mod, "_auto_sync_loop"),
+    ):
+        gdrive_mod.start_auto_sync(MagicMock())
+    assert mock_create.call_count == 1
+
+
+def _relay_session_stub() -> MagicMock:
+    session = MagicMock()
+    session.relay_url = "https://relay.example.com/authorize"
+    session.session_id = "sess_test"
+    return session
+
+
+def _run_ensure_config(monkeypatch, tmp_path, cf: bool) -> AsyncMock:
+    """Drive ensure_config(force=True) with the relay client fully faked."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.setenv("MCP_RELAY_URL", "https://relay.example.com")
+    monkeypatch.delenv("MCP_STORAGE_BACKEND", raising=False)
+    if cf:
+        monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    else:
+        monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
+
+    setup_mock = AsyncMock()
+    with (
+        patch(
+            "mcp_core.relay.client.create_session",
+            new=AsyncMock(return_value=_relay_session_stub()),
+        ),
+        patch(
+            "mcp_core.relay.client.poll_for_result",
+            new=AsyncMock(return_value={"JINA_AI_API_KEY": "k"}),
+        ),
+        patch("wet_mcp.relay_setup.PerPluginStore"),
+        patch("wet_mcp.relay_setup.apply_config"),
+        patch("httpx.AsyncClient") as mock_client,
+        patch("wet_mcp.sync.setup_google_auth", setup_mock),
+    ):
+        http = MagicMock()
+        http.__aenter__.return_value = MagicMock(post=AsyncMock())
+        mock_client.return_value = http
+        asyncio.run(ensure_config(force=True, timeout=1.0))
+    return setup_mock
+
+
+def test_relay_setup_gdrive_oauth_skipped_on_cf(monkeypatch, tmp_path):
+    """F9: on CF the relay wizard must not run the GDrive OAuth setup either."""
+
+    setup_mock = _run_ensure_config(monkeypatch, tmp_path, cf=True)
+    assert setup_mock.await_count == 0
+
+
+def test_relay_setup_gdrive_oauth_runs_off_cf(monkeypatch, tmp_path):
+    """Control: without the CF marker the wizard still offers GDrive OAuth."""
+    setup_mock = _run_ensure_config(monkeypatch, tmp_path, cf=False)
+    assert setup_mock.await_count == 1

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -46,7 +46,6 @@
     // Model, endpoint, and provider key are selected per authenticated subject
     // through the relay (per-sub); keep no model/provider lock in Worker vars.
     // Standard chains: cohere/embed-v4.0 + cohere/rerank-v4.0-fast via CF AI Gateway.
-    "LLM_MODELS": "openrouter/minimax/minimax-m3:free,openrouter/z-ai/glm-5.2:free",
     "SEARCH_BACKEND": "searxng",
     "WET_AUTO_SEARXNG": "false"
   },

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -43,9 +43,10 @@
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "${CF_VECTORIZE_ID}",
-    "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
-    "RERANK_MODELS": "jina_ai/jina-reranker-v3",
-    "LLM_MODELS": "openrouter/minimax/minimax-m3",
+    // Model, endpoint, and provider key are selected per authenticated subject
+    // through the relay (per-sub); keep no model/provider lock in Worker vars.
+    // Standard chains: cohere/embed-v4.0 + cohere/rerank-v4.0-fast via CF AI Gateway.
+    "LLM_MODELS": "openrouter/minimax/minimax-m3:free,openrouter/z-ai/glm-5.2:free",
     "SEARCH_BACKEND": "searxng",
     "WET_AUTO_SEARXNG": "false"
   },


### PR DESCRIPTION
- relay wizard + start_auto_sync skip GDrive on cf-d1 (F9 follow-up, +3 regression tests)
- drop EMBEDDING_MODELS/RERANK_MODELS jina pins from deploy template: embed/rerank are per-sub relay config via CF AI Gateway (cohere/embed-v4.0 + rerank-v4.0-fast)
- LLM_MODELS: openrouter/minimax-minimax-m3:free -> z-ai/glm-5.2:free (deepseek-v4-flash-0731 free tier no longer exists upstream; paid fallback deepseek/deepseek-v4-flash-latest stays a per-sub choice)