### PR TITLE
fix(deploy): use Browser Run as sole renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ Run your own single-user wet instance serverless on Cloudflare (Containers + D1 
    docker build --target http --build-arg SLIM=1 -t wet-mcp:beta .
    wrangler containers push wet-mcp:beta   # prints registry.cloudflare.com/<ACCOUNT_ID>/wet-mcp:beta
    ```
-5. Set secrets (use `SEARXNG_URL` with basic-auth userinfo, e.g.
-   `https://user:pass@searxng.example.com`, or `TAVILY_API_KEY` if you set `SEARCH_BACKEND=tavily`):
+5. Set secrets (`TAVILY_API_KEY` is required when `SEARCH_BACKENDS` includes
+   `tavily`; Cloudflare Browser Run is the default headless render backend):
    ```
    wrangler secret put CREDENTIAL_SECRET
    wrangler secret put JINA_AI_API_KEY
@@ -345,17 +345,16 @@ Run your own single-user wet instance serverless on Cloudflare (Containers + D1 
    wrangler secret put XAI_API_KEY
    wrangler secret put MCP_RELAY_PASSWORD
    wrangler secret put MCP_DCR_SERVER_SECRET
-   wrangler secret put SEARXNG_URL
-   wrangler secret put BROWSERLESS_URL          # render backend (BROWSER_BACKENDS default = browserless,cf-browser-rendering)
-   wrangler secret put BROWSERLESS_TOKEN
+   wrangler secret put TAVILY_API_KEY
    wrangler secret put CF_BROWSER_RENDERING_TOKEN
    ```
 6. `wrangler deploy` and complete setup in the browser relay form at your Worker domain.
 
 Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (credentials/tokens, encrypted),
-`DOCS_DB_BACKEND=cf-d1` (docs + BM25 full-text), and Vectorize (embeddings). Web search uses
-a SearXNG instance (`SEARCH_BACKEND=searxng`, `SEARXNG_URL`) or Tavily (`SEARCH_BACKEND=tavily`);
-embed/rerank are forced cloud via `EMBEDDING_MODELS`/`RERANK_MODELS`.
+`DOCS_DB_BACKEND=cf-d1` (docs + BM25 full-text), and Vectorize (embeddings). The
+example Worker uses `SEARCH_BACKENDS=tavily,duckduckgo,startpage` and
+`BROWSER_BACKENDS=cf-browser-rendering`; embed/rerank are forced cloud via
+`EMBEDDING_MODELS`/`RERANK_MODELS`.
 
 ## Smithery
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,8 +42,8 @@ export interface Env {
   EMBEDDING_MODELS: string
   RERANK_MODELS: string
   LLM_MODELS: string
-  SEARCH_BACKEND: string
-  WET_AUTO_SEARXNG: string
+  SEARCH_BACKEND?: string
+  WET_AUTO_SEARXNG?: string
   PUBLIC_URL: string
   CREDENTIAL_SECRET: string
   JINA_AI_API_KEY: string
@@ -51,7 +51,7 @@ export interface Env {
   XAI_API_KEY: string
   MCP_RELAY_PASSWORD: string
   MCP_DCR_SERVER_SECRET: string
-  // search secrets — exactly one set depending on SEARCH_BACKEND
+  // Optional search provider credentials.
   SEARXNG_URL?: string
   TAVILY_API_KEY?: string
   // Capability provider chains (search/browser) + per-task disable-local toggles.

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -31,14 +31,13 @@
   "vectorize": [{ "binding": "VECTORIZE", "index_name": "${CF_VECTORIZE_ID}" }],
   "vars": {
     "DISABLE_LOCAL_SEARCH": "true",
-    "BROWSERLESS_URL": "https://browserless.n24q02m.com",
     "DISABLE_LOCAL_BROWSER": "true",
     "DISABLE_LOCAL_EMBED": "true",
     // Paired with the line above: the SLIM image uninstalls fastretrieval, so the
     // local leg is absent for rerank too. See wrangler.jsonc for why the
     // deploy-level RERANK_MODELS does not cover the per-sub case.
     "DISABLE_LOCAL_RERANK": "true",
-    "BROWSER_BACKENDS": "browserless,cf-browser-rendering",
+    "BROWSER_BACKENDS": "cf-browser-rendering",
     "CF_ACCOUNT_ID": "${CLOUDFLARE_ACCOUNT_ID}",
     "PUBLIC_URL": "${PUBLIC_URL}",
     "MCP_STORAGE_BACKEND": "cf-kv",
@@ -51,8 +50,7 @@
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
     "LLM_MODELS": "openrouter/minimax/minimax-m3",
-    "SEARCH_BACKEND": "searxng",
-    "WET_AUTO_SEARXNG": "false"
+    "SEARCH_BACKENDS": "tavily,duckduckgo,startpage"
   },
   "observability": { "enabled": true }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,7 +31,7 @@
   // Non-secret container config (forwarded into the container by WetContainer.envVars).
   // Secrets via `wrangler secret put`: CREDENTIAL_SECRET, JINA_AI_API_KEY,
   // GOOGLE_VERTEX_EXPRESS_API_KEY, XAI_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET,
-  // and SEARXNG_URL (with basic-auth userinfo) — or TAVILY_API_KEY if SEARCH_BACKEND=tavily.
+  // TAVILY_API_KEY, and CF_BROWSER_RENDERING_TOKEN.
   "vars": {
     "DISABLE_LOCAL_SEARCH": "true",
     "DISABLE_LOCAL_BROWSER": "true",
@@ -44,7 +44,7 @@
     // order. The deploy-level RERANK_MODELS below does not cover that case; it
     // is process env, and per-sub chains resolve from the sub's bucket.
     "DISABLE_LOCAL_RERANK": "true",
-    "BROWSER_BACKENDS": "browserless,cf-browser-rendering",
+    "BROWSER_BACKENDS": "cf-browser-rendering",
     "CF_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
     "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",
@@ -57,8 +57,7 @@
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
     "LLM_MODELS": "openrouter/minimax/minimax-m3",
-    "SEARCH_BACKEND": "searxng",
-    "WET_AUTO_SEARXNG": "false"
+    "SEARCH_BACKENDS": "tavily,duckduckgo,startpage"
   },
   "routes": [{ "pattern": "<YOUR_WORKER_DOMAIN>", "custom_domain": true }],
   "observability": { "enabled": true }


### PR DESCRIPTION
## Change
- make Cloudflare Browser Run the sole headless backend in Worker deploy configs
- remove production Browserless/SearXNG deployment defaults
- use `SEARCH_BACKENDS=tavily,duckduckgo,startpage`
- update Cloudflare deployment docs

## Verification
- dedicated account-owned `Browser Run Write` token live-probed against `/browser-rendering/content`
- Worker secret `CF_BROWSER_RENDERING_TOKEN` provisioned and read back
- `uv run pytest tests/test_browser_backends.py tests/test_search_backends_extended.py -q` (33 passed)
- `bunx vitest run --dir tests worker.test.ts` (18 passed)
- `wrangler deploy --dry-run` bundles `BROWSER_BACKENDS=cf-browser-rendering` and no Browserless/SearXNG vars