### PR TITLE
fix: pin BSR action to v1.6.1 stable (6e688489)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,7 +69,7 @@ jobs:
       # so the computed version is identical. Gated the same way as the real step so it
       # is skipped in the publish_existing_tag recovery path (that path deliberately
       # reuses a known tag/version and does not need this guard).
-      - uses: n24q02m/better-semantic-release@69319fae1169b6ee7b89565c7b54b55d1531d42e # v1.6.0
+      - uses: n24q02m/better-semantic-release@6e6884898bfe1ac34a0bc64ed62f54a21562df23 # v1.6.1
         id: dryrun
         if: inputs.publish_existing_tag == ''
         with:
@@ -139,7 +139,7 @@ jobs:
           echo "::error::Could not verify whether ${PKG} ${COMPUTED_VERSION} exists on PyPI: ${URL} returned HTTP '${status:-<no response>}' (expected 200 or 404). Refusing to proceed so a genuine collision cannot slip through as a false 'free'. Re-run the release once the registry is reachable."
           exit 1
 
-      - uses: n24q02m/better-semantic-release@69319fae1169b6ee7b89565c7b54b55d1531d42e # v1.6.0
+      - uses: n24q02m/better-semantic-release@6e6884898bfe1ac34a0bc64ed62f54a21562df23 # v1.6.1
         id: release
         if: inputs.publish_existing_tag == ''
         with:


### PR DESCRIPTION
Bumps the `n24q02m/better-semantic-release` action pin from `69319fae1169b6ee7b89565c7b54b55d1531d42e` (`v1.6.0`) to `6e6884898bfe1ac34a0bc64ed62f54a21562df23` (v1.6.1 release commit).

- File: `.github/workflows/cd.yml` (2 pin lines)
- Audit-recovery wave W8, plan P2b
- This wave only opens PRs; repo CI validates this change.